### PR TITLE
Update demos for JSON editor changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@typescript-eslint/eslint-plugin": "5.4.0",
         "@typescript-eslint/parser": "^5.16.0",
         "autoprefixer": "10.4.4",
-        "caniuse-lite": "^1.0.30001385",
+        "caniuse-lite": "^1.0.30001393",
         "dotenv": "^10.0.0",
         "eslint": "^8.11.0",
         "eslint-config-prettier": "8.3.0",
@@ -3530,9 +3530,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001385",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001385.tgz",
-      "integrity": "sha512-MpiCqJGhBkHgpyimE9GWmZTnyHyEEM35u115bD3QBrXpjvL/JgcP8cUhKJshfmg4OtEHFenifcK5sZayEw5tvQ==",
+      "version": "1.0.30001393",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001393.tgz",
+      "integrity": "sha512-N/od11RX+Gsk+1qY/jbPa0R6zJupEa0lxeBG598EbrtblxVCTJsQwbRBm6+V+rxpc5lHKdsXb9RY83cZIPLseA==",
       "dev": true,
       "funding": [
         {
@@ -16360,9 +16360,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001385",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001385.tgz",
-      "integrity": "sha512-MpiCqJGhBkHgpyimE9GWmZTnyHyEEM35u115bD3QBrXpjvL/JgcP8cUhKJshfmg4OtEHFenifcK5sZayEw5tvQ==",
+      "version": "1.0.30001393",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001393.tgz",
+      "integrity": "sha512-N/od11RX+Gsk+1qY/jbPa0R6zJupEa0lxeBG598EbrtblxVCTJsQwbRBm6+V+rxpc5lHKdsXb9RY83cZIPLseA==",
       "dev": true
     },
     "capture-exit": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@typescript-eslint/eslint-plugin": "5.4.0",
     "@typescript-eslint/parser": "^5.16.0",
     "autoprefixer": "10.4.4",
-    "caniuse-lite": "^1.0.30001385",
+    "caniuse-lite": "^1.0.30001393",
     "dotenv": "^10.0.0",
     "eslint": "^8.11.0",
     "eslint-config-prettier": "8.3.0",

--- a/src/components/solution-spatial-ref/readme.md
+++ b/src/components/solution-spatial-ref/readme.md
@@ -7,12 +7,12 @@
 
 ## Properties
 
-| Property      | Attribute      | Description                                                                     | Type       | Default  |
-| ------------- | -------------- | ------------------------------------------------------------------------------- | ---------- | -------- |
-| `defaultWkid` | `default-wkid` | The wkid that will be used as the default when no user selection has been made. | `number`   | `102100` |
-| `locked`      | `locked`       | When true, all but the main switch are disabled to prevent interaction.         | `boolean`  | `true`   |
-| `services`    | --             | List of service names the spatial reference should apply to                     | `string[]` | `[]`     |
-| `value`       | `value`        | Contains the public value for this component.                                   | `string`   | `null`   |
+| Property      | Attribute      | Description                                                                     | Type       | Default                       |
+| ------------- | -------------- | ------------------------------------------------------------------------------- | ---------- | ----------------------------- |
+| `defaultWkid` | `default-wkid` | The wkid that will be used as the default when no user selection has been made. | `number`   | `102100`                      |
+| `locked`      | `locked`       | When true, all but the main switch are disabled to prevent interaction.         | `boolean`  | `true`                        |
+| `services`    | --             | List of service names the spatial reference should apply to                     | `string[]` | `[]`                          |
+| `value`       | `value`        | Contains the public value for this component.                                   | `string`   | `this.defaultWkid.toString()` |
 
 
 ## Events

--- a/src/components/solution-spatial-ref/solution-spatial-ref.tsx
+++ b/src/components/solution-spatial-ref/solution-spatial-ref.tsx
@@ -57,12 +57,17 @@ export class SolutionSpatialRef {
   /**
    * Contains the public value for this component.
    */
-  @Prop({ mutable: true, reflect: true }) value: string = null;
+  @Prop({ mutable: true, reflect: true }) value: string = this.defaultWkid.toString();
 
   @Watch("value")
   valueChanged(newValue: string): void {
     this.spatialRef = this._createSpatialRefDisplay(newValue);
     this._updateStore();
+    const searchBox = document.getElementById("calcite-sr-search") as HTMLCalciteInputElement;
+    if (searchBox) {
+      searchBox.value = this._srSearchText = "";
+    }
+    this._clearSelection();
   }
 
   /**
@@ -112,6 +117,7 @@ export class SolutionSpatialRef {
             {this.translations.spatialReferenceInfo}
             <label class="spatial-ref-default">
               <calcite-input
+                id="calcite-sr-search"
                 disabled={this.locked}
                 onCalciteInputInput={(evt) => this._searchSpatialReferences(evt)}
                 onKeyDown={(evt) => this._inputKeyDown(evt)}
@@ -264,7 +270,7 @@ export class SolutionSpatialRef {
 
   /**
    * Enable spatial reference variable for all feature services.
-   * 
+   *
    * @param services list of service names
    */
   private _setFeatureServiceDefaults(
@@ -429,7 +435,7 @@ export class SolutionSpatialRef {
     } else {
       return (
         <div class={containerClass} id={id}>
-          {this._getTreeItem(this.defaultWkid.toString(), true)}
+          {this._getTreeItem(this.value.toString(), true)}
         </div>
       );
     }

--- a/src/components/solution-template-data/solution-template-data.scss
+++ b/src/components/solution-template-data/solution-template-data.scss
@@ -19,9 +19,15 @@
 }
 
 .solution-data-container {
-  @apply h-full
-    w-full
-    relative;
+  position: absolute;
+  height: -moz-available;  /* This doesn't work in Firefox, but if we don't specify it and then override it with the next line, it gets automatically inserted */
+  height: calc(100% - 48px);
+  height: -webkit-fill-available;  /* Mozilla-based browsers will ignore this. */
+  height: stretch;
+  width: -moz-available;  /* This doesn't work in Firefox, but if we don't specify it and then override it with the next line, it gets automatically inserted */
+  width: 100%;
+  width: -webkit-fill-available;  /* Mozilla-based browsers will ignore this. */
+  width: stretch;
 }
 
 .solution-data-child-container {

--- a/src/components/store-manager/store-manager.tsx
+++ b/src/components/store-manager/store-manager.tsx
@@ -18,7 +18,7 @@
  * The json-editor componet leverages a stencil/store to manage data.
  * If a component uses the json-editor but does not have logic to hydrate the store this component can be used.
  * It will create and hydrate the store based on the value provided.
- * 
+ *
  * The value must be a string so it can be observed by the MutationObserver implemented below.
  * The observer does not notify when passing complex attributes as you can with stencil.
  *
@@ -27,7 +27,7 @@
 
 import { Component, Element, Event, EventEmitter, Prop } from '@stencil/core';
 import state from '../../utils/editStore';
-import { getModels, getFeatureServices, getSpatialReferenceInfo } from '../../utils/templates';
+import { /*getModels,*/ getFeatureServices, getSpatialReferenceInfo } from '../../utils/templates';
 import { getItemDataAsJson, UserSession } from '@esri/solution-common';
 
 @Component({
@@ -100,6 +100,7 @@ export class StoreManager {
    * When we get a new value we are dealinmg with a new solution and need to fetch the items data and load the state.
    */
   private _initValueObserver() {
+    const self = this;
     this._valueObserver = new MutationObserver(ml => {
       ml.some(mutation => {
         const newValue = mutation.target[mutation.attributeName];
@@ -107,12 +108,12 @@ export class StoreManager {
           newValue !== mutation.oldValue && newValue !== "") {
           const v = JSON.parse(newValue);
           // eslint-disable-next-line @typescript-eslint/no-floating-promises
-          getItemDataAsJson(v, this.authentication).then(data => {
-            state.models = getModels(Array.isArray(v) ? v : [v], this.authentication, v);
+          getItemDataAsJson(v, self.authentication).then(data => {
+            //state.models = getModels(Array.isArray(v) ? v : [v], self.authentication, v);
             state.featureServices = getFeatureServices(Array.isArray(v) ? v : [v])
             state.spatialReferenceInfo = getSpatialReferenceInfo(state.featureServices, data);
-            this.templates = v;
-            this.stateLoaded.emit(state);
+            self.templates = v;
+            self.stateLoaded.emit(state);
           });
           return true;
         }

--- a/src/demos/browse-solutions.html
+++ b/src/demos/browse-solutions.html
@@ -129,6 +129,11 @@
   <script src="./monacoConfig.js"></script>
   <script>
     let continueFcn, authentication;
+    require.config({
+      "paths": {
+        "vs": "./libs/monaco-editor"
+      }
+    });
     require(['vs/editor/editor.main'],
     function () {
 
@@ -141,7 +146,7 @@
         authentication = new arcgisRest.UserSession({
           username: document.getElementById("username").value || undefined,
           password: document.getElementById("password").value || undefined,
-          portal 
+          portal
         });
 
         // Initialize the configuration content

--- a/src/demos/solution-configuration.html
+++ b/src/demos/solution-configuration.html
@@ -89,7 +89,7 @@
     </div>
     <div class="labeled-item align-baseline">
       <label for="group">Group ID:&nbsp;</label>
-      <input type="text" id="group" style="width:256px" placeholder="aa0b71e70e5b464187879db8fad7d939">
+      <input type="text" id="group" style="width:300px">
     </div>
     <button id="connectBtn fader" onclick="connectFcn()">Connect</button>
   </div>

--- a/src/demos/solution-configuration.html
+++ b/src/demos/solution-configuration.html
@@ -94,7 +94,7 @@
     <button id="connectBtn fader" onclick="connectFcn()">Connect</button>
   </div>
   <div class="list flex not-visible margin-bottom-1 margin-side-1" id="componentContainer">
-    <calcite-select 
+    <calcite-select
       id="solution-ids"
       label="demo combobox"
       placeholder="Select Solution ID"
@@ -112,6 +112,11 @@
   <script src="./libs/setLocale.js"></script>
   <script src="./monacoConfig.js"></script>
   <script>
+    require.config({
+      "paths": {
+        "vs": "./libs/monaco-editor"
+      }
+    });
     require(['vs/editor/editor.main'],
     function () {
 
@@ -125,7 +130,7 @@
         authentication = new arcgisRest.UserSession({
           username: document.getElementById("username").value || undefined,
           password: document.getElementById("password").value || undefined,
-          portal 
+          portal
         });
 
         // Initialize the configuration content

--- a/src/demos/solution-configuration.html
+++ b/src/demos/solution-configuration.html
@@ -50,6 +50,9 @@
     display: inline-flex;
     margin-inline-end: 8px;
   }
+  .loginLabel {
+    min-width: unset;
+  }
   .margin-top-1 {
     margin-top: 1rem;
   }
@@ -76,19 +79,19 @@
   <h1>Demo Solution Configuration</h1>
   <div class="margin-top-1 margin-side-1">
     <div class="labeled-item align-baseline">
-      <label for="username">Username:&nbsp;</label>
+      <label class="loginLabel" for="username">Username:&nbsp;</label>
       <input type="text" id="username" placeholder="anonymous">
     </div>
     <div class="labeled-item align-baseline">
-      <label for="password">Password:&nbsp;</label>
+      <label class="loginLabel" for="password">Password:&nbsp;</label>
       <input type="password" id="password">
     </div>
     <div class="labeled-item align-baseline">
-      <label for="portal">Portal:&nbsp;</label>
+      <label class="loginLabel" for="portal">Portal:&nbsp;</label>
       <input type="text" id="portal" style="width:256px" placeholder="https://www.arcgis.com">
     </div>
     <div class="labeled-item align-baseline">
-      <label for="group">Group ID:&nbsp;</label>
+      <label class="loginLabel" for="group">Group ID:&nbsp;</label>
       <input type="text" id="group" style="width:300px">
     </div>
     <button id="connectBtn fader" onclick="connectFcn()">Connect</button>

--- a/src/demos/solution-item.html
+++ b/src/demos/solution-item.html
@@ -46,6 +46,11 @@
   <script src="./libs/setLocale.js"></script>
   <script src="./monacoConfig.js"></script>
   <script>
+    require.config({
+      "paths": {
+        "vs": "./libs/monaco-editor"
+      }
+    });
     require(['vs/editor/editor.main'],
     function () {
       // Initialize the configuration content
@@ -64,7 +69,7 @@
         .then(results => Promise.all(results.map(r => r.json())))
         .then(jsonResults => {
           helper.value = JSON.stringify(jsonResults[4].templates[0]);
-          
+
           const itemDetails = jsonResults[0].value;
           const value = jsonResults[1].value;
           demo.value = {

--- a/src/demos/solution-template-data.html
+++ b/src/demos/solution-template-data.html
@@ -46,10 +46,9 @@
   <script src="./libs/setLocale.js"></script>
   <script src="./monacoConfig.js"></script>
   <script>
-    var package_path = window.location.pathname.substring(0, window.location.pathname.lastIndexOf('/'));
     require.config({
       "paths": {
-        "vs": package_path + "/libs/monaco-editor"
+        "vs": "./libs/monaco-editor"
       }
     });
     require(["vs/editor/editor.main"],


### PR DESCRIPTION
Miscellaneous changes
* Added Monaco editor config to solution-item and solution-template-data demos
* Temporarily skip StoreManager's `getModels` call
* Upon selecting a spatial reference from search results, clear the search box and display the selection as the current value
* Adjustments to template-data editor container for Firefox
* Handle `this` in StoreManager value-observer callback
* Unoverlap login prompts in solution-configuration demo
* Updated caniuse-lite
