### PR TITLE
Initial steps to integrate standalone store

### DIFF
--- a/src/assets/t9n/solution-configuration/resources.json
+++ b/src/assets/t9n/solution-configuration/resources.json
@@ -1,5 +1,13 @@
 {
     "cancelEdits": "Cancel Edits",
     "definitionTab": "Definition",
-    "spatialReferenceTab": "Spatial Reference"
+    "geocodeUrl": "Geocode URL",
+    "geometryUrl": "Geometry URL",
+    "itemId": "Item ID",
+    "portalBaseUrl": "Portal base URL",
+    "routeUrl": "Route URL",
+    "solutionExtent": "Solution extent",
+    "solutionItemExtent": "Solution item extent",
+    "spatialReferenceTab": "Spatial Reference",
+    "url": "URL"
 }

--- a/src/assets/t9n/solution-configuration/resources_en.json
+++ b/src/assets/t9n/solution-configuration/resources_en.json
@@ -1,5 +1,13 @@
 {
     "cancelEdits": "Cancel Edits",
     "definitionTab": "Definition",
-    "spatialReferenceTab": "Spatial Reference"
+    "geocodeUrl": "Geocode URL",
+    "geometryUrl": "Geometry URL",
+    "itemId": "Item ID",
+    "portalBaseUrl": "Portal base URL",
+    "routeUrl": "Route URL",
+    "solutionExtent": "Solution extent",
+    "solutionItemExtent": "Solution item extent",
+    "spatialReferenceTab": "Spatial Reference",
+    "url": "URL"
 }

--- a/src/components/json-editor/json-editor.tsx
+++ b/src/components/json-editor/json-editor.tsx
@@ -153,6 +153,8 @@ export class JsonEditor {
 
   /**
    * StencilJS: Called once just after the component is first connected to the DOM.
+   *
+   * @returns Promise when complete
    */
   async componentWillLoad(): Promise<void> {
     this._initValueObserver();

--- a/src/components/solution-item-details/solution-item-details.scss
+++ b/src/components/solution-item-details/solution-item-details.scss
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-$snippet-width: 400px;
+$thumbnail-width: 363px;
 
 .inputBottomSeparation {
   @apply mt-0
@@ -36,7 +36,7 @@ $snippet-width: 400px;
 .img-container {
   @apply inline
     m-inline-end-4;
-  max-width: $snippet-width;
+  max-width: $thumbnail-width;
 }
 
 .summary-count-container {
@@ -46,7 +46,7 @@ $snippet-width: 400px;
 }
 
 .snippet-count-container {
-  width: calc(100vw - $snippet-width);
+  width: calc(100vw - $thumbnail-width);
 }
 
 .parent-container {

--- a/src/components/solution-template-data/solution-template-data.scss
+++ b/src/components/solution-template-data/solution-template-data.scss
@@ -35,7 +35,7 @@
     w-full
     flex
     flex-col
-    overflow-hidden;
+    overflow-y-auto;
 }
 
 .solution-data-editor-container {
@@ -72,7 +72,6 @@
   @apply pt-4
     pb-0
     px-4;
-  max-height: 45%;
 }
 
 .sol-vars {

--- a/src/demos/index.html
+++ b/src/demos/index.html
@@ -94,6 +94,8 @@
         </ul>
         <br>
         <calcite-link href="./browse-solutions.html" target="_blank">Solution Browser</calcite-link>
+        <br>
+        <calcite-link href="./new-solution-configuration.html" target="_blank">&lt;solution-configuration&gt; alternate UI</calcite-link>
       </div>
       <br>
       <div>

--- a/src/demos/new-solution-configuration.html
+++ b/src/demos/new-solution-configuration.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+  <title>Solution Configuration</title>
+  <!--
+   | Copyright 2022 Esri
+   |
+   | Licensed under the Apache License, Version 2.0 (the "License");
+   | you may not use this file except in compliance with the License.
+   | You may obtain a copy of the License at
+   |
+   |    http://www.apache.org/licenses/LICENSE-2.0
+   |
+   | Unless required by applicable law or agreed to in writing, software
+   | distributed under the License is distributed on an "AS IS" BASIS,
+   | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   | See the License for the specific language governing permissions and
+   | limitations under the License.
+  -->
+
+  <link rel="stylesheet" href="https://unpkg.com/@esri/calcite-components@1.0.0-beta.94/dist/calcite/calcite.css" type="text/css" />
+  <link rel="stylesheet" href="https://webapps-cdn.esri.com/CDN/fonts/v1.4.1/fonts.css" />
+  <link rel="stylesheet" href="../solutions.css" type="text/css">
+  <style>
+  .full-height {
+    height: 100%;
+  }
+  .app-container {
+    height: calc(100% - 30px);
+    overflow: auto;
+  }
+  .demo-button {
+    position: relative;
+    align-self: center;
+  }
+  .list {
+    padding-inline-end: 100px;
+  }
+  .flex {
+    display: flex;
+  }
+  .combo-list {
+    width: 330px;
+  }
+  .section-title {
+    margin-bottom: 12px;
+  }
+  .align-baseline {
+    align-items: baseline;
+  }
+  .labeled-item {
+    display: inline-flex;
+    margin-inline-end: 8px;
+  }
+  .loginLabel {
+    min-width: unset;
+  }
+  .margin-top-1 {
+    margin-top: 1rem;
+  }
+  .margin-bottom-1 {
+    margin-bottom: 1rem;
+  }
+  .margin-side-1 {
+    margin-inline-end: 1rem;
+    margin-inline-start: 1rem;
+  }
+  .not-visible {
+    visibility: hidden;
+  }
+  </style>
+  <script src="https://polyfill.io/v3/polyfill.min.js?features=es5%2Cfetch%2CPromise"></script>
+  <script src="https://unpkg.com/@esri/arcgis-rest-request@3.5.0/dist/umd/request.umd.min.js"></script>
+  <script src="https://unpkg.com/@esri/arcgis-rest-auth@3.5.0/dist/umd/auth.umd.min.js"></script>
+  <script src="https://unpkg.com/@esri/arcgis-rest-portal@3.5.0/dist/umd/portal.umd.min.js"></script>
+  <script src="https://unpkg.com/@esri/solution-common@1.5.0/dist/umd/common.umd.min.js"></script>
+  <script type="module" src="https://unpkg.com/@esri/calcite-components@1.0.0-beta.94/dist/calcite/calcite.esm.js"></script>
+  <script type="module" src="../solutions.esm.js"></script>
+</head>
+
+<body>
+  <h1>Demo Solution Configuration</h1>
+  <div class="app-container">
+    <div class="margin-top-1 margin-side-1">
+      <div class="margin-side-1" style="color:red">DO NOT USE REAL SOLUTION ITEMS WHILE SAVE EDITS WORK IS IN PROGRESS...CAN DESTROY THE SOLUTION ITEM</div>
+      <div class="labeled-item align-baseline">
+        <label class="loginLabel" for="username">Username:&nbsp;</label>
+        <input type="text" id="username" placeholder="anonymous">
+      </div>
+      <div class="labeled-item align-baseline">
+        <label class="loginLabel" for="password">Password:&nbsp;</label>
+        <input type="password" id="password">
+      </div>
+      <div class="labeled-item align-baseline">
+        <label class="loginLabel" for="portal">Portal:&nbsp;</label>
+        <input type="text" id="portal" style="width:256px" placeholder="https://www.arcgis.com">
+      </div>
+      <div class="labeled-item align-baseline">
+        <label class="loginLabel" for="solutionId">Solution ID:&nbsp;</label>
+        <input type="text" id="solutionId" style="width:300px" oninput="solnIdChangedFcn()">
+      </div>
+      <button id="configureBtn" onclick="configureFcn()" disabled>Configure</button>
+    </div>
+  </div>
+
+  <calcite-modal id="configurationModal" fullscreen>
+    <div slot="header" id="modal-title">Configure Solution</div>
+    <div slot="content" class="full-height">
+      <div class="full-height">
+        <solution-configuration id="demo"></solution-configuration>
+      </div>
+    </div>
+    <calcite-button slot="secondary" width="full" appearance="outline" onclick="cancelFcn()">Cancel</calcite-button>
+    <calcite-button slot="primary" width="full" onclick="saveFcn()">Save</calcite-button>
+  </calcite-modal>
+
+  <script src="./libs/require.js"></script>
+  <script src="./libs/setLocale.js"></script>
+  <script src="./monacoConfig.js"></script>
+  <script>
+    require.config({
+      "paths": {
+        "vs": "./libs/monaco-editor"
+      }
+    });
+    require(["vs/editor/editor.main"],
+    function () {
+      const appContainer = document.getElementById("configurationModal");
+      const configureBtn = document.getElementById("configureBtn");
+      const solutionId = document.getElementById("solutionId");
+      appContainer.beforeClose = cancel;
+      cancelFcn = cancel;
+      configureFcn = configureSolution;
+      saveFcn = save;
+      solnIdChangedFcn = solnIdChanged;
+      authentication = null;
+      solutionIdRegEx = /[0-9a-f]{32}/i;
+
+      // Check for changes before closing modal
+      function cancel() {
+        console.log("Check for changes before closing");
+        alert("Check for changes before closing");
+        appContainer.open = false;
+        return Promise.resolve();
+      }
+
+      // Open configuration modal
+      async function configureSolution() {
+        const portal = (document.getElementById("portal").value || "https://www.arcgis.com") + "/sharing/rest";
+        authentication = new arcgisRest.UserSession({
+          username: document.getElementById("username").value || undefined,
+          password: document.getElementById("password").value || undefined,
+          portal
+        });
+
+        // Initialize the configuration content
+        let demo = document.getElementById("demo");
+        demo.authentication = authentication;
+
+        const solutionId = document.getElementById("solutionId").value;
+
+        if (solutionId) {
+          const itemBase = await arcgisSolution.getItemBase(solutionId, authentication);
+          const modalTitle = document.getElementById("modal-title");
+          modalTitle.innerHTML = `Configure Solution ${itemBase.title}`;
+
+          demo.solutionItemId = solutionId;
+          demo.addEventListener("templatesChanged",
+            (e) => {
+              console.log("templatesChanged " + JSON.stringify(e, null, 2));
+            }
+          );
+
+          appContainer.open = true;
+        }
+      }
+
+      // Save changes and close the modal
+      function save() {
+        console.log("Saving and closing");
+        alert("Saving and closing");
+        appContainer.open = false;
+      }
+
+      // Enables `configure` button if a guid is in the Solution ID input box
+      function solnIdChanged() {
+        configureBtn.disabled = !solutionIdRegEx.test(solutionId.value);
+      }
+
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Created a variant of the solution-configuration demo page as an initial step towards integrating the standalone store.  This UI asks for a solution ID, and then displays the configuration in a modal.

This variant remains connected to the original solution-configuration component, but doesn't have the code to set that component up, and so the configuration display will be empty.

Also,
* added i18n for solution and organization variables
* added a missing return doc
* made solution and organization variables display scrollable
* aligned right side of snippet box with other item details boxes

![image](https://user-images.githubusercontent.com/2125181/193351049-dcd9b007-25c9-4fc9-9bf1-e446d46171ed.png)