### PR TITLE
Simplified async/Promise use

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -46,6 +46,7 @@
     "@typescript-eslint/no-unsafe-member-access": "off",
     "@typescript-eslint/no-unsafe-return": "off",
     "@typescript-eslint/no-unused-vars": "off",
+    "@typescript-eslint/require-await": "off",
     "@typescript-eslint/restrict-template-expressions": "off",
     "curly": "error",
     "jest/expect-expect": "off",

--- a/src/components/buffer-tools/buffer-tools.tsx
+++ b/src/components/buffer-tools/buffer-tools.tsx
@@ -307,7 +307,6 @@ export class BufferTools {
   protected async _getTranslations(): Promise<void> {
     const messages = await getLocaleComponentStrings(this.el);
     this._translations = messages[0] as typeof BufferTools_T9n;
-    return Promise.resolve();
   }
 
 }

--- a/src/components/map-draw-tools/map-draw-tools.tsx
+++ b/src/components/map-draw-tools/map-draw-tools.tsx
@@ -146,9 +146,8 @@ export class MapDrawTools {
    * @returns Promise that resolves when the operation is complete
    */
   @Method()
-  clear(): Promise<void> {
+  async clear(): Promise<void> {
     this._clearSketch();
-    return Promise.resolve();
   }
 
   //--------------------------------------------------------------------------
@@ -171,7 +170,6 @@ export class MapDrawTools {
   async componentWillLoad(): Promise<void> {
     await this._getTranslations();
     await this._initModules();
-    return Promise.resolve();
   }
 
   /**
@@ -309,6 +307,5 @@ export class MapDrawTools {
   protected async _getTranslations(): Promise<void> {
     const translations = await getLocaleComponentStrings(this.el);
     this._translations = translations[0] as typeof MapDrawTools_T9n;
-    return Promise.resolve();
   }
 }

--- a/src/components/map-layer-picker/map-layer-picker.tsx
+++ b/src/components/map-layer-picker/map-layer-picker.tsx
@@ -82,7 +82,6 @@ export class MapLayerPicker {
         this.layerSelectionChange.emit([this.layerNames[0]]);
       }
     }
-    return Promise.resolve();
   }
 
   //--------------------------------------------------------------------------
@@ -115,7 +114,6 @@ export class MapLayerPicker {
         this.selectedLayers.length === 1 ? [this.selectedLayers[0]] : [this.layerNames[0]]
       );
     }
-    return Promise.resolve();
   }
 
   /**

--- a/src/components/map-search/map-search.tsx
+++ b/src/components/map-search/map-search.tsx
@@ -104,7 +104,6 @@ export class MapSearch {
   @Method()
   async clear(): Promise<void> {
     this._searchWidget.clear();
-    return Promise.resolve();
   }
 
   //--------------------------------------------------------------------------
@@ -127,7 +126,6 @@ export class MapSearch {
   async componentWillLoad(): Promise<void> {
     await this._getTranslations();
     await this._initModules();
-    return Promise.resolve();
   }
 
   /**
@@ -220,6 +218,5 @@ export class MapSearch {
   protected async _getTranslations(): Promise<void> {
     const translations = await getLocaleComponentStrings(this.el);
     this._translations = translations[0] as typeof MapSearch_T9n;
-    return Promise.resolve();
   }
 }

--- a/src/components/map-select-tools/map-select-tools.tsx
+++ b/src/components/map-select-tools/map-select-tools.tsx
@@ -306,7 +306,6 @@ export class MapSelectTools {
   async componentWillLoad(): Promise<void> {
     await this._getTranslations();
     await this._initModules();
-    return Promise.resolve();
   }
 
   /**
@@ -437,7 +436,6 @@ export class MapSelectTools {
     this._initGraphicsLayer();
     this._initSelectionSet();
     this._initSearchWidget();
-    return Promise.resolve();
   }
 
   /**
@@ -555,7 +553,6 @@ export class MapSelectTools {
       );
     }
     this.selectionSetChange.emit(ids.length);
-    return Promise.resolve();
   }
 
   /**
@@ -583,7 +580,6 @@ export class MapSelectTools {
       });
       void this._highlightFeatures(this._selectedIds);
     //}, 100);
-    return Promise.resolve();
   }
 
   /**
@@ -642,7 +638,6 @@ export class MapSelectTools {
       }
       void this._geomQuery(this.geometries);
     }
-    return Promise.resolve();
   }
 
   /**
@@ -715,7 +710,6 @@ export class MapSelectTools {
       void this._drawTools.clear();
     }
     this.selectionSetChange.emit(this._selectedIds.length);
-    return Promise.resolve();
   }
 
   /**
@@ -746,6 +740,5 @@ export class MapSelectTools {
   protected async _getTranslations(): Promise<void> {
     const translations = await getLocaleComponentStrings(this.el);
     this._translations = translations[0] as typeof MapSelectTools_T9n;
-    return Promise.resolve();
   }
 }

--- a/src/components/pdf-download/pdf-download.tsx
+++ b/src/components/pdf-download/pdf-download.tsx
@@ -123,7 +123,6 @@ export class PdfDownload {
    */
   async componentWillLoad(): Promise<void> {
     await this._getTranslations();
-    return Promise.resolve();
   }
 
   /**
@@ -183,7 +182,6 @@ export class PdfDownload {
   ): Promise<void> {
     const l = this._labelInfoControl.selectedOption.value;
     alert(`PDF download: (${this._getLabelSizeText(l)}) (remove dups: ${removeDuplicates}) ${ids.join(", ")}`);
-    return Promise.resolve();
   }
 
   /**
@@ -229,7 +227,6 @@ export class PdfDownload {
   protected async _getTranslations(): Promise<void> {
     const translations = await getLocaleComponentStrings(this.el);
     this._translations = translations[0] as typeof PdfDownload_T9n;
-    return Promise.resolve();
   }
 
 }

--- a/src/components/public-notification/public-notification.tsx
+++ b/src/components/public-notification/public-notification.tsx
@@ -119,7 +119,6 @@ export class PublicNotification {
         this.selectionSets = [];
       }
     }
-    return Promise.resolve();
   }
 
   @Watch('pageType')
@@ -131,7 +130,6 @@ export class PublicNotification {
     if (v === EPageType.LIST || v === EPageType.REFINE || v === EPageType.PDF || v === EPageType.CSV) {
       return this._highlightFeatures();
     }
-    return Promise.resolve();
   }
 
   //--------------------------------------------------------------------------
@@ -872,6 +870,5 @@ export class PublicNotification {
   protected async _getTranslations(): Promise<void> {
     const translations = await getLocaleComponentStrings(this.el);
     this._translations = translations[0] as typeof NewPublicNotification_T9n;
-    return Promise.resolve();
   }
 }

--- a/src/components/refine-selection-tools/refine-selection-tools.tsx
+++ b/src/components/refine-selection-tools/refine-selection-tools.tsx
@@ -152,13 +152,11 @@ export class RefineSelectionTools {
   @Method()
   async reset(): Promise<void> {
     this.ids = [];
-    return Promise.resolve();
   }
 
   @Method()
   async clearHighlight(): Promise<void> {
     this._clearHighlight();
-    return Promise.resolve();
   }
 
   //--------------------------------------------------------------------------
@@ -183,7 +181,6 @@ export class RefineSelectionTools {
   async componentWillLoad(): Promise<void> {
     await this._getTranslations();
     await this._initModules();
-    return Promise.resolve();
   }
 
   /**
@@ -428,11 +425,9 @@ export class RefineSelectionTools {
 
      return Promise.all(layerPromises).then((layerViews) => {
         this.layerViews = layerViews;
-        return Promise.resolve();
       });
     } else {
       this.selectEnabled = false;
-      return Promise.resolve();
     }
   }
 
@@ -509,7 +504,6 @@ export class RefineSelectionTools {
         });
       }
       this._clear();
-      return Promise.resolve();
     });
   }
 
@@ -587,6 +581,5 @@ export class RefineSelectionTools {
   protected async _getTranslations(): Promise<void> {
     const translations = await getLocaleComponentStrings(this.el);
     this._translations = translations[0] as typeof RefineSelectionTools_T9n;
-    return Promise.resolve();
   }
 }

--- a/src/components/refine-selection/refine-selection.tsx
+++ b/src/components/refine-selection/refine-selection.tsx
@@ -382,7 +382,6 @@ export class RefineSelection {
    protected async _getTranslations(): Promise<void> {
     const translations = await getLocaleComponentStrings(this.el);
     this._translations = translations[0] as typeof RefineSelection_T9n;
-    return Promise.resolve();
   }
 
 }

--- a/src/components/solution-configuration/solution-configuration.tsx
+++ b/src/components/solution-configuration/solution-configuration.tsx
@@ -654,6 +654,5 @@ export class SolutionConfiguration {
   protected async _getTranslations(): Promise<void> {
     const translations = await getLocaleComponentStrings(this.el);
     this._translations = translations[0] as typeof SolutionConfiguration_T9n;
-    return Promise.resolve();
   }
 }

--- a/src/components/solution-item-details/solution-item-details.tsx
+++ b/src/components/solution-item-details/solution-item-details.tsx
@@ -351,6 +351,5 @@ export class SolutionItemDetails {
   protected async _getTranslations(): Promise<void> {
     const translations = await getLocaleComponentStrings(this.el);
     this._translations = translations[0] as typeof SolutionItemDetails_T9n;
-    return Promise.resolve();
   }
 }

--- a/src/components/solution-item-sharing/solution-item-sharing.tsx
+++ b/src/components/solution-item-sharing/solution-item-sharing.tsx
@@ -176,6 +176,5 @@ export class SolutionItemSharing {
   protected async _getTranslations(): Promise<void> {
     const translations = await getLocaleComponentStrings(this.el);
     this._translations = translations[0] as typeof SolutionItemSharing_T9n;
-    return Promise.resolve();
   }
 }

--- a/src/components/solution-item/solution-item.tsx
+++ b/src/components/solution-item/solution-item.tsx
@@ -232,6 +232,5 @@ export class SolutionItem {
   protected async _getTranslations(): Promise<void> {
     const translations = await getLocaleComponentStrings(this.el);
     this._translations = translations[0] as typeof SolutionItem_T9n;
-    return Promise.resolve();
   }
 }

--- a/src/components/solution-organization-variables/solution-organization-variables.tsx
+++ b/src/components/solution-organization-variables/solution-organization-variables.tsx
@@ -157,6 +157,5 @@ export class SolutionOrganizationVariables {
   protected async _getTranslations(): Promise<void> {
     const translations = await getLocaleComponentStrings(this.el);
     this._translations = translations[0] as typeof SolutionOrganizationVariables_T9n;
-    return Promise.resolve();
   }
 }

--- a/src/components/solution-resource-item/solution-resource-item.tsx
+++ b/src/components/solution-resource-item/solution-resource-item.tsx
@@ -445,6 +445,5 @@ export class SolutionResourceItem {
   protected async _getTranslations(): Promise<void> {
     const translations = await getLocaleComponentStrings(this.el);
     this._translations = translations[0] as typeof SolutionResourceItem_T9n;
-    return Promise.resolve();
   }
 }

--- a/src/components/solution-spatial-ref/solution-spatial-ref.tsx
+++ b/src/components/solution-spatial-ref/solution-spatial-ref.tsx
@@ -477,6 +477,5 @@ export class SolutionSpatialRef {
   protected async _getTranslations(): Promise<void> {
     const translations = await getLocaleComponentStrings(this.el);
     this._translations = translations[0] as typeof SolutionSpatialRef_T9n;
-    return Promise.resolve();
   }
 }

--- a/src/components/solution-template-data/solution-template-data.tsx
+++ b/src/components/solution-template-data/solution-template-data.tsx
@@ -193,6 +193,5 @@ export class SolutionTemplateData {
   protected async _getTranslations(): Promise<void> {
     const translations = await getLocaleComponentStrings(this.el);
     this._translations = translations[0] as typeof SolutionTemplateData_T9n;
-    return Promise.resolve();
   }
 }

--- a/src/components/solution-variables/solution-variables.tsx
+++ b/src/components/solution-variables/solution-variables.tsx
@@ -178,6 +178,5 @@ export class SolutionVariables {
   protected async _getTranslations(): Promise<void> {
     const translations = await getLocaleComponentStrings(this.el);
     this._translations = translations[0] as typeof SolutionVariables_T9n;
-    return Promise.resolve();
   }
 }

--- a/src/utils/solution-store.ts
+++ b/src/utils/solution-store.ts
@@ -185,7 +185,6 @@ class SolutionStore
         this._store.state.templateEdits[k].original = {...this._store.state.templateEdits[k].current};
       }
     );
-    return Promise.resolve();
   }
 
   /**
@@ -217,7 +216,6 @@ class SolutionStore
     } else {
       this._emptyTheStore();
     }
-    return Promise.resolve();
   }
 
   /**
@@ -263,7 +261,6 @@ class SolutionStore
         this._store.state.templateEdits[k].current = {...this._store.state.templateEdits[k].original};
       }
     );
-    return Promise.resolve();
   }
 
   //------------------------------------------------------------------------------------------------------------------//


### PR DESCRIPTION
Because [async is automatically wrapped](https://github.com/Esri/solutions-components/pull/77#discussion_r988149353), removing extraneous Promise calls