### PR TITLE
Fixed false change state for groups

### DIFF
--- a/src/components/json-editor/json-editor.tsx
+++ b/src/components/json-editor/json-editor.tsx
@@ -142,7 +142,9 @@ export class JsonEditor {
           // Set the changed state & dispatch event if state has changed, but only if there are no errors
           if (!self.hasErrors) {
             self._flagEditorHasChanges(self._currentModel?.canUndo());
-            self._flagEditorContentChanged();
+            if (self._currentModel?.canUndo()) {
+              self._flagEditorContentChanged();
+            }
           }
 
           // Show the error flag if there are errors


### PR DESCRIPTION
When one edited a group's details, saved, re-entered the configuration, and then selected the group, the configuration was flagged as changed: the Cancel and Save buttons became active.

This flagging was caused by the JSON editor; the fix is to be more reserved about raising the `solutionEditorContentChanged` event.