### PR TITLE
Loads a solution if the solution id is already available when the constructor is executed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,18 +10,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@arcgis/core": "^4.24.7",
-        "@esri/arcgis-rest-auth": "^3.4.2",
-        "@esri/arcgis-rest-feature-layer": "^3.4.2",
-        "@esri/arcgis-rest-portal": "^3.4.2",
-        "@esri/arcgis-rest-request": "^3.4.2",
-        "@esri/arcgis-rest-service-admin": "^3.4.2",
-        "@esri/calcite-components": "1.0.0-beta.97",
-        "@esri/hub-common": "9.29.0",
-        "@esri/hub-initiatives": "9.29.0",
-        "@esri/hub-sites": "9.29.0",
-        "@esri/hub-teams": "9.29.0",
-        "@esri/solution-common": "1.5.3",
-        "@types/arcgis-js-api": "^4.24.0",
         "minimist": "^1.2.6"
       },
       "devDependencies": {
@@ -30,6 +18,7 @@
         "@stencil/postcss": "^2.1.0",
         "@stencil/sass": "^2.0.0",
         "@stencil/store": "^2.0.1",
+        "@types/arcgis-js-api": "^4.24.0",
         "@types/jest": "^27.0.3",
         "@types/node": "^16.11.11",
         "@types/puppeteer": "^5.4.2",
@@ -58,6 +47,19 @@
         "ts-node": "^10.4.0",
         "tslib": "^2.4.0",
         "typescript": "^4.8.4"
+      },
+      "peerDependencies": {
+        "@esri/arcgis-rest-auth": "^3.4.2",
+        "@esri/arcgis-rest-feature-layer": "^3.4.2",
+        "@esri/arcgis-rest-portal": "^3.4.2",
+        "@esri/arcgis-rest-request": "^3.4.2",
+        "@esri/arcgis-rest-service-admin": "^3.4.2",
+        "@esri/calcite-components": "1.0.0-beta.97",
+        "@esri/hub-common": "9.29.0",
+        "@esri/hub-initiatives": "9.29.0",
+        "@esri/hub-sites": "9.29.0",
+        "@esri/hub-teams": "9.29.0",
+        "@esri/solution-common": "1.5.3"
       }
     },
     "node_modules/@a11y/focus-trap": {
@@ -721,6 +723,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-3.0.0.tgz",
       "integrity": "sha512-fb3EsfPnNoBaTV3ZmEGSED+9j3i8CQzhTlH+fNIqKHgPXde1IOUcUIeIrxYgxYIy02J8SZb9Q8ebPTTuwiKxEQ==",
+      "peer": true,
       "dependencies": {
         "xss": "^1.0.14"
       }
@@ -729,6 +732,7 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.5.0.tgz",
       "integrity": "sha512-EeKfGxSLEI2KvGE2FvN+kYDR+a7RWLf+uNzsYDXWK/8wOYrtj+lh091NHxgHU/Fd+NDoAcHSoTSPCCEpgS0Gsg==",
+      "peer": true,
       "dependencies": {
         "@esri/arcgis-rest-types": "^3.5.0",
         "tslib": "^1.13.0"
@@ -740,12 +744,14 @@
     "node_modules/@esri/arcgis-rest-auth/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "peer": true
     },
     "node_modules/@esri/arcgis-rest-feature-layer": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.5.0.tgz",
       "integrity": "sha512-+qjJnwPaYYNQqce20FF1iNvQ1BeFVue6ka8MnDu4BNhSeyw9OKD2WoI1pXfKVkSHpXTHeQIfyMVLC7/nFNja8g==",
+      "peer": true,
       "dependencies": {
         "@esri/arcgis-rest-types": "^3.5.0",
         "tslib": "^1.13.0"
@@ -758,12 +764,14 @@
     "node_modules/@esri/arcgis-rest-feature-layer/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "peer": true
     },
     "node_modules/@esri/arcgis-rest-portal": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.5.0.tgz",
       "integrity": "sha512-rrl/eUWOxdA5Y0MDYuvCopwNkf8loIfVIE4j1kGRTIz32n4uqdhb38sYKd2X4JK8QW67vyKq0SqxMSIYOHGXQg==",
+      "peer": true,
       "dependencies": {
         "@esri/arcgis-rest-types": "^3.5.0",
         "tslib": "^1.13.0"
@@ -776,12 +784,14 @@
     "node_modules/@esri/arcgis-rest-portal/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "peer": true
     },
     "node_modules/@esri/arcgis-rest-request": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.5.0.tgz",
       "integrity": "sha512-FlI32b2EF/SlJeGe8GZtVqIlvHDxI18bgIB2vQINi9fAC07F1Jg3JMglDTDSl8CCYS/9cYp62n7lWPUwmvn/xQ==",
+      "peer": true,
       "dependencies": {
         "tslib": "^1.10.0"
       }
@@ -789,12 +799,14 @@
     "node_modules/@esri/arcgis-rest-request/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "peer": true
     },
     "node_modules/@esri/arcgis-rest-service-admin": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.5.0.tgz",
       "integrity": "sha512-gZzqb0I9kAyIIx2bBTU070QSEd5CV7C0vyd5IBWZOJqgkvA4Yf/LOPCMZ2s/+y2jF+4B1vRMGjpInovvfEk9Rw==",
+      "peer": true,
       "dependencies": {
         "@esri/arcgis-rest-types": "^3.5.0",
         "tslib": "^1.13.0"
@@ -808,12 +820,14 @@
     "node_modules/@esri/arcgis-rest-service-admin/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "peer": true
     },
     "node_modules/@esri/arcgis-rest-types": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.5.0.tgz",
-      "integrity": "sha512-xXc0Xr1LB7kMnr7wNSbfibJpDY5zPfCfif+WJjBX1VzhHgZxxhRnmVzrw+Wh2lAQoN0OhqqqFNkxsVS+mY0Aiw=="
+      "integrity": "sha512-xXc0Xr1LB7kMnr7wNSbfibJpDY5zPfCfif+WJjBX1VzhHgZxxhRnmVzrw+Wh2lAQoN0OhqqqFNkxsVS+mY0Aiw==",
+      "peer": true
     },
     "node_modules/@esri/calcite-colors": {
       "version": "6.0.1",
@@ -824,6 +838,7 @@
       "version": "1.0.0-beta.97",
       "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.0.0-beta.97.tgz",
       "integrity": "sha512-pvuOQI01DCIr6kS+Jof/b5kLWRaDlYZStP8QUB5r4FYofHHST25iKlOS6525WD4S9xejthfb8S1PehTeMn5Wxg==",
+      "peer": true,
       "dependencies": {
         "@a11y/focus-trap": "1.0.5",
         "@floating-ui/dom": "1.0.3",
@@ -900,6 +915,7 @@
       "version": "9.29.0",
       "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.29.0.tgz",
       "integrity": "sha512-wKnkmv3RnXqzniXecnhQ1PX523l1fqaYHtgzhjyY4r0xei55Jmt989iVs2YwVqcIoFEzlqvHvOHYNV2wIQ/6gQ==",
+      "peer": true,
       "dependencies": {
         "abab": "^2.0.5",
         "adlib": "^3.0.7",
@@ -918,12 +934,14 @@
     "node_modules/@esri/hub-common/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "peer": true
     },
     "node_modules/@esri/hub-initiatives": {
       "version": "9.29.0",
       "resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.29.0.tgz",
       "integrity": "sha512-nRyR51X95d3iO3JmyfUzxE1tQV3wY3JLW/iq/7f6oUwUb7Wv/3EoZR1gjZuZreIzxVJBNfTwjaEjBVzRQ6tzRQ==",
+      "peer": true,
       "dependencies": {
         "tslib": "^1.13.0"
       },
@@ -937,12 +955,14 @@
     "node_modules/@esri/hub-initiatives/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "peer": true
     },
     "node_modules/@esri/hub-sites": {
       "version": "9.29.0",
       "resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.29.0.tgz",
       "integrity": "sha512-KkxwArXRZq8LID2adjADQ/uXskMWVWmPcwb+4PWVAIPJBRyAXms9aNsM/oY1pZdD97RXt8Y39OKZkpZsda62IA==",
+      "peer": true,
       "dependencies": {
         "tslib": "^1.13.0"
       },
@@ -958,12 +978,14 @@
     "node_modules/@esri/hub-sites/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "peer": true
     },
     "node_modules/@esri/hub-teams": {
       "version": "9.29.0",
       "resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.29.0.tgz",
       "integrity": "sha512-LryHH6DOPNY5ztdBSMUtouAnJ98sGz5dT7MjE3poSZoyks8RhKoOY/5FHuoMKhn+RTa5zRX3EHrgI2u0ScjoZw==",
+      "peer": true,
       "dependencies": {
         "tslib": "^1.13.0"
       },
@@ -978,12 +1000,14 @@
     "node_modules/@esri/hub-teams/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "peer": true
     },
     "node_modules/@esri/solution-common": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-1.5.3.tgz",
       "integrity": "sha512-K45GaTgkJ1ojw3YCK1fye3bN03OwG448oOvyQrFmu1XMHwycTgexGTabUuq2EitghYesOI4CaLF/8zdusiVgsQ==",
+      "peer": true,
       "dependencies": {
         "@esri/arcgis-html-sanitizer": "3.0.0",
         "@types/lodash.isplainobject": "^4.0.7",
@@ -1008,17 +1032,20 @@
     "node_modules/@esri/solution-common/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "peer": true
     },
     "node_modules/@floating-ui/core": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.1.tgz",
-      "integrity": "sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA=="
+      "integrity": "sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA==",
+      "peer": true
     },
     "node_modules/@floating-ui/dom": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.3.tgz",
       "integrity": "sha512-6H1kwjkOZKabApNtXRiYHvMmYJToJ1DV7rQ3xc/WJpOABhQIOJJOdz2AOejj8X+gcybaFmBpisVTZxBZAM3V0w==",
+      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.0.1"
       }
@@ -2024,7 +2051,8 @@
     "node_modules/@types/arcgis-js-api": {
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/@types/arcgis-js-api/-/arcgis-js-api-4.24.0.tgz",
-      "integrity": "sha512-Qh6Yw1g4cBq1UGoX1xI+G+4NgxZgTgmSj6IdV8CE9k7IRdPOZIHeEC5ZHDjf93mgjbD8vytPZWHVvcYs1F/PDw=="
+      "integrity": "sha512-Qh6Yw1g4cBq1UGoX1xI+G+4NgxZgTgmSj6IdV8CE9k7IRdPOZIHeEC5ZHDjf93mgjbD8vytPZWHVvcYs1F/PDw==",
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.1.16",
@@ -2284,12 +2312,14 @@
     "node_modules/@types/lodash": {
       "version": "4.14.184",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.184.tgz",
-      "integrity": "sha512-RoZphVtHbxPZizt4IcILciSWiC6dcn+eZ8oX9IWEYfDMcocdd42f7NPI6fQj+6zI8y4E0L7gu2pcZKLGTRaV9Q=="
+      "integrity": "sha512-RoZphVtHbxPZizt4IcILciSWiC6dcn+eZ8oX9IWEYfDMcocdd42f7NPI6fQj+6zI8y4E0L7gu2pcZKLGTRaV9Q==",
+      "peer": true
     },
     "node_modules/@types/lodash.isplainobject": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/@types/lodash.isplainobject/-/lodash.isplainobject-4.0.7.tgz",
       "integrity": "sha512-fdHtdjpy7fXydEaRHx1dPa+2AVmLbmk2Gv7f0w/90BKCH0DkWo8pIrzygnB3rvgo6oKNb3cO9VaPpj9GLCr5Ug==",
+      "peer": true,
       "dependencies": {
         "@types/lodash": "*"
       }
@@ -2717,6 +2747,7 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
       "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+      "peer": true,
       "dependencies": {
         "esm": "^3.2.25"
       }
@@ -3156,6 +3187,7 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
       "integrity": "sha512-0l7mVU+LrQ2X/ZTUq63T5i3VyR2aTgcRTFmBcD6djQ/Fek6q1A9t5u0F4jZVYHzp78jwWAzGfLpAY1b4/I3lfg==",
+      "peer": true,
       "dependencies": {
         "babel-runtime": "^6.22.0",
         "core-js": "^2.4.0",
@@ -3205,6 +3237,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
+      "peer": true,
       "dependencies": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -3213,7 +3246,8 @@
     "node_modules/babel-runtime/node_modules/regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "peer": true
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -4103,7 +4137,8 @@
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
       "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
       "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
-      "hasInstallScript": true
+      "hasInstallScript": true,
+      "peer": true
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -4557,6 +4592,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "peer": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
@@ -4565,6 +4601,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -5162,6 +5199,7 @@
       "version": "3.2.25",
       "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
       "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -5622,6 +5660,7 @@
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.2.4.tgz",
       "integrity": "sha512-19R4aaHzqsTe7gyL3wthWiyYyNFqVK1tzO6BMEAQEKRu4R3ptkl4FyuEtUMOPKdYsO6k6C/Ym3YJ6eCL49OdSw==",
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "he": "~1.1.1",
         "nimnjs": "^1.1.0",
@@ -6154,6 +6193,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -6165,6 +6205,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6296,6 +6337,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha512-z/GDPjlRMNOa2XJiB4em8wJpuuBfrFOlYKTZxtpkdr1uPdibHI8rYA3MY0KDObpVyaes0e/aunid/t88ZI2EKA==",
+      "peer": true,
       "bin": {
         "he": "bin/he"
       }
@@ -6409,7 +6451,8 @@
     "node_modules/immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "peer": true
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -9043,7 +9086,8 @@
     "node_modules/json-typescript": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/json-typescript/-/json-typescript-1.1.2.tgz",
-      "integrity": "sha512-Np07MUsYMKbB0nNlw/MMIRjUK7ehO48LA4FsrzrhCfTUxMKbvOBAo0sc0b4nQ80ge9d32sModCunCgoyUojgUA=="
+      "integrity": "sha512-Np07MUsYMKbB0nNlw/MMIRjUK7ehO48LA4FsrzrhCfTUxMKbvOBAo0sc0b4nQ80ge9d32sModCunCgoyUojgUA==",
+      "peer": true
     },
     "node_modules/json5": {
       "version": "2.2.0",
@@ -9064,6 +9108,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/jsonapi-typescript/-/jsonapi-typescript-0.1.3.tgz",
       "integrity": "sha512-uPcPS01GeM+4HIyn18s7l1yD2S3uLZy2TX1UkQffCM0bLb3TMwudXUyVXPHTMZ4vdZT8MqKqN2vjB5PogTAdFQ==",
+      "peer": true,
       "dependencies": {
         "json-typescript": "^1.0.0"
       }
@@ -9085,6 +9130,7 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
       "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "peer": true,
       "dependencies": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
@@ -9157,6 +9203,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
       "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "peer": true,
       "dependencies": {
         "immediate": "~3.0.5"
       }
@@ -9546,17 +9593,20 @@
     "node_modules/nimn_schema_builder": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/nimn_schema_builder/-/nimn_schema_builder-1.1.0.tgz",
-      "integrity": "sha512-DK5/B8CM4qwzG2URy130avcwPev4uO0ev836FbQyKo1ms6I9z/i6EJyiZ+d9xtgloxUri0W+5gfR8YbPq7SheA=="
+      "integrity": "sha512-DK5/B8CM4qwzG2URy130avcwPev4uO0ev836FbQyKo1ms6I9z/i6EJyiZ+d9xtgloxUri0W+5gfR8YbPq7SheA==",
+      "peer": true
     },
     "node_modules/nimn-date-parser": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/nimn-date-parser/-/nimn-date-parser-1.0.0.tgz",
-      "integrity": "sha512-1Nf+x3EeMvHUiHsVuEhiZnwA8RMeOBVTQWfB1S2n9+i6PYCofHd2HRMD+WOHIHYshy4T4Gk8wQoCol7Hq3av8Q=="
+      "integrity": "sha512-1Nf+x3EeMvHUiHsVuEhiZnwA8RMeOBVTQWfB1S2n9+i6PYCofHd2HRMD+WOHIHYshy4T4Gk8wQoCol7Hq3av8Q==",
+      "peer": true
     },
     "node_modules/nimnjs": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/nimnjs/-/nimnjs-1.3.2.tgz",
       "integrity": "sha512-TIOtI4iqkQrUM1tiM76AtTQem0c7e56SkDZ7sj1d1MfUsqRcq2ZWQvej/O+HBTZV7u/VKnwlKTDugK/75IRPPw==",
+      "peer": true,
       "dependencies": {
         "nimn_schema_builder": "^1.0.0",
         "nimn-date-parser": "^1.0.0"
@@ -9957,6 +10007,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/opencollective/-/opencollective-1.0.3.tgz",
       "integrity": "sha512-YBRI0Qa8+Ui0/STV1qYuPrJm889PT3oCPHMVoL+8Y3nwCffj7PSrB2NlGgrhgBKDujxTjxknHWJ/FiqOsYcIDw==",
+      "peer": true,
       "dependencies": {
         "babel-polyfill": "6.23.0",
         "chalk": "1.1.3",
@@ -9974,6 +10025,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
       "integrity": "sha512-wiXutNjDUlNEDWHcYH3jtZUhd3c4/VojassD8zHdHCY13xbZy2XbW+NKQwA0tWGBVzDA9qEzYwfoSsWmviidhw==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9982,6 +10034,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9990,6 +10043,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9998,6 +10052,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^2.2.1",
         "escape-string-regexp": "^1.0.2",
@@ -10012,12 +10067,14 @@
     "node_modules/opencollective/node_modules/chardet": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-      "integrity": "sha512-j/Toj7f1z98Hh2cYo2BVr85EpIRWqUi7rtRSGxh/cqUjqrnJe9l9UE7IUGd2vQ2p+kSHLkSzObQPZPLUC6TQwg=="
+      "integrity": "sha512-j/Toj7f1z98Hh2cYo2BVr85EpIRWqUi7rtRSGxh/cqUjqrnJe9l9UE7IUGd2vQ2p+kSHLkSzObQPZPLUC6TQwg==",
+      "peer": true
     },
     "node_modules/opencollective/node_modules/cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==",
+      "peer": true,
       "dependencies": {
         "restore-cursor": "^2.0.0"
       },
@@ -10028,12 +10085,14 @@
     "node_modules/opencollective/node_modules/cli-width": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
-      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw=="
+      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
+      "peer": true
     },
     "node_modules/opencollective/node_modules/external-editor": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+      "peer": true,
       "dependencies": {
         "chardet": "^0.4.0",
         "iconv-lite": "^0.4.17",
@@ -10047,6 +10106,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==",
+      "peer": true,
       "dependencies": {
         "escape-string-regexp": "^1.0.5"
       },
@@ -10058,6 +10118,7 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.0.6.tgz",
       "integrity": "sha512-thluxTGBXUGb8DuQcvH9/CM/CrcGyB5xUpWc9x6Slqcq1z/hRr2a6KxUpX4ddRfmbe0hg3E4jTvo5833aWz3BA==",
+      "peer": true,
       "dependencies": {
         "ansi-escapes": "^1.1.0",
         "chalk": "^1.0.0",
@@ -10078,6 +10139,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -10086,6 +10148,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10094,6 +10157,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -10101,17 +10165,20 @@
     "node_modules/opencollective/node_modules/minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha512-7Wl+Jz+IGWuSdgsQEJ4JunV0si/iMhg42MnQQG6h1R6TNeVenp4U9x5CC5v/gYqz/fENLQITAWXidNtVL0NNbw=="
+      "integrity": "sha512-7Wl+Jz+IGWuSdgsQEJ4JunV0si/iMhg42MnQQG6h1R6TNeVenp4U9x5CC5v/gYqz/fENLQITAWXidNtVL0NNbw==",
+      "peer": true
     },
     "node_modules/opencollective/node_modules/mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ=="
+      "integrity": "sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ==",
+      "peer": true
     },
     "node_modules/opencollective/node_modules/node-fetch": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
       "integrity": "sha512-BDxbhLHXFFFvilHjh9xihcDyPkXQ+kjblxnl82zAX41xUYSNvuRpFRznmldR9+OKu+p+ULZ7hNoyunlLB5ecUA==",
+      "peer": true,
       "dependencies": {
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
@@ -10121,6 +10188,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==",
+      "peer": true,
       "dependencies": {
         "mimic-fn": "^1.0.0"
       },
@@ -10132,6 +10200,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==",
+      "peer": true,
       "dependencies": {
         "onetime": "^2.0.0",
         "signal-exit": "^3.0.2"
@@ -10144,6 +10213,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "peer": true,
       "dependencies": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
@@ -10156,6 +10226,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
       "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -10164,6 +10235,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^3.0.0"
       },
@@ -10175,6 +10247,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -10186,6 +10259,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -10194,6 +10268,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
       "integrity": "sha512-iPBWbPP4OEOzR1xfhpGLDh+ypKBOygunZhM9jBtA7FS5sKjEiMZw0EFb82hnDOmTZX90ZWLoZKUza4cVt8MexA==",
+      "peer": true,
       "dependencies": {
         "object-assign": "^4.0.1",
         "pinkie-promise": "^2.0.0"
@@ -10409,7 +10484,8 @@
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "peer": true
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -10538,6 +10614,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10546,6 +10623,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
+      "peer": true,
       "dependencies": {
         "pinkie": "^2.0.0"
       },
@@ -11127,7 +11205,8 @@
     "node_modules/regenerator-runtime": {
       "version": "0.10.5",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-      "integrity": "sha512-02YopEIhAgiBHWeoTiA8aitHDt8z6w+rQqNuIftlM+ZtvSl/brTouaU7DW6GO/cHtvxJvS4Hwv2ibKdxIRi24w=="
+      "integrity": "sha512-02YopEIhAgiBHWeoTiA8aitHDt8z6w+rQqNuIftlM+ZtvSl/brTouaU7DW6GO/cHtvxJvS4Hwv2ibKdxIRi24w==",
+      "peer": true
     },
     "node_modules/regex-not": {
       "version": "1.0.2",
@@ -11410,7 +11489,8 @@
     "node_modules/rx": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-      "integrity": "sha512-CiaiuN6gapkdl+cZUr67W6I8jquN4lkak3vtIsIWCl4XIPP8ffsoyN6/+PuGXnQy8Cu8W2y9Xxh31Rq4M6wUug=="
+      "integrity": "sha512-CiaiuN6gapkdl+cZUr67W6I8jquN4lkak3vtIsIWCl4XIPP8ffsoyN6/+PuGXnQy8Cu8W2y9Xxh31Rq4M6wUug==",
+      "peer": true
     },
     "node_modules/rxjs": {
       "version": "7.4.0",
@@ -11845,7 +11925,8 @@
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "peer": true
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -14302,6 +14383,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-3.0.0.tgz",
       "integrity": "sha512-fb3EsfPnNoBaTV3ZmEGSED+9j3i8CQzhTlH+fNIqKHgPXde1IOUcUIeIrxYgxYIy02J8SZb9Q8ebPTTuwiKxEQ==",
+      "peer": true,
       "requires": {
         "xss": "^1.0.14"
       }
@@ -14310,6 +14392,7 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.5.0.tgz",
       "integrity": "sha512-EeKfGxSLEI2KvGE2FvN+kYDR+a7RWLf+uNzsYDXWK/8wOYrtj+lh091NHxgHU/Fd+NDoAcHSoTSPCCEpgS0Gsg==",
+      "peer": true,
       "requires": {
         "@esri/arcgis-rest-types": "^3.5.0",
         "tslib": "^1.13.0"
@@ -14318,7 +14401,8 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "peer": true
         }
       }
     },
@@ -14326,6 +14410,7 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.5.0.tgz",
       "integrity": "sha512-+qjJnwPaYYNQqce20FF1iNvQ1BeFVue6ka8MnDu4BNhSeyw9OKD2WoI1pXfKVkSHpXTHeQIfyMVLC7/nFNja8g==",
+      "peer": true,
       "requires": {
         "@esri/arcgis-rest-types": "^3.5.0",
         "tslib": "^1.13.0"
@@ -14334,7 +14419,8 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "peer": true
         }
       }
     },
@@ -14342,6 +14428,7 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.5.0.tgz",
       "integrity": "sha512-rrl/eUWOxdA5Y0MDYuvCopwNkf8loIfVIE4j1kGRTIz32n4uqdhb38sYKd2X4JK8QW67vyKq0SqxMSIYOHGXQg==",
+      "peer": true,
       "requires": {
         "@esri/arcgis-rest-types": "^3.5.0",
         "tslib": "^1.13.0"
@@ -14350,7 +14437,8 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "peer": true
         }
       }
     },
@@ -14358,6 +14446,7 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.5.0.tgz",
       "integrity": "sha512-FlI32b2EF/SlJeGe8GZtVqIlvHDxI18bgIB2vQINi9fAC07F1Jg3JMglDTDSl8CCYS/9cYp62n7lWPUwmvn/xQ==",
+      "peer": true,
       "requires": {
         "tslib": "^1.10.0"
       },
@@ -14365,7 +14454,8 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "peer": true
         }
       }
     },
@@ -14373,6 +14463,7 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.5.0.tgz",
       "integrity": "sha512-gZzqb0I9kAyIIx2bBTU070QSEd5CV7C0vyd5IBWZOJqgkvA4Yf/LOPCMZ2s/+y2jF+4B1vRMGjpInovvfEk9Rw==",
+      "peer": true,
       "requires": {
         "@esri/arcgis-rest-types": "^3.5.0",
         "tslib": "^1.13.0"
@@ -14381,14 +14472,16 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "peer": true
         }
       }
     },
     "@esri/arcgis-rest-types": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.5.0.tgz",
-      "integrity": "sha512-xXc0Xr1LB7kMnr7wNSbfibJpDY5zPfCfif+WJjBX1VzhHgZxxhRnmVzrw+Wh2lAQoN0OhqqqFNkxsVS+mY0Aiw=="
+      "integrity": "sha512-xXc0Xr1LB7kMnr7wNSbfibJpDY5zPfCfif+WJjBX1VzhHgZxxhRnmVzrw+Wh2lAQoN0OhqqqFNkxsVS+mY0Aiw==",
+      "peer": true
     },
     "@esri/calcite-colors": {
       "version": "6.0.1",
@@ -14399,6 +14492,7 @@
       "version": "1.0.0-beta.97",
       "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.0.0-beta.97.tgz",
       "integrity": "sha512-pvuOQI01DCIr6kS+Jof/b5kLWRaDlYZStP8QUB5r4FYofHHST25iKlOS6525WD4S9xejthfb8S1PehTeMn5Wxg==",
+      "peer": true,
       "requires": {
         "@a11y/focus-trap": "1.0.5",
         "@floating-ui/dom": "1.0.3",
@@ -14451,6 +14545,7 @@
       "version": "9.29.0",
       "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.29.0.tgz",
       "integrity": "sha512-wKnkmv3RnXqzniXecnhQ1PX523l1fqaYHtgzhjyY4r0xei55Jmt989iVs2YwVqcIoFEzlqvHvOHYNV2wIQ/6gQ==",
+      "peer": true,
       "requires": {
         "abab": "^2.0.5",
         "adlib": "^3.0.7",
@@ -14462,7 +14557,8 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "peer": true
         }
       }
     },
@@ -14470,6 +14566,7 @@
       "version": "9.29.0",
       "resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.29.0.tgz",
       "integrity": "sha512-nRyR51X95d3iO3JmyfUzxE1tQV3wY3JLW/iq/7f6oUwUb7Wv/3EoZR1gjZuZreIzxVJBNfTwjaEjBVzRQ6tzRQ==",
+      "peer": true,
       "requires": {
         "tslib": "^1.13.0"
       },
@@ -14477,7 +14574,8 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "peer": true
         }
       }
     },
@@ -14485,6 +14583,7 @@
       "version": "9.29.0",
       "resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.29.0.tgz",
       "integrity": "sha512-KkxwArXRZq8LID2adjADQ/uXskMWVWmPcwb+4PWVAIPJBRyAXms9aNsM/oY1pZdD97RXt8Y39OKZkpZsda62IA==",
+      "peer": true,
       "requires": {
         "tslib": "^1.13.0"
       },
@@ -14492,7 +14591,8 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "peer": true
         }
       }
     },
@@ -14500,6 +14600,7 @@
       "version": "9.29.0",
       "resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.29.0.tgz",
       "integrity": "sha512-LryHH6DOPNY5ztdBSMUtouAnJ98sGz5dT7MjE3poSZoyks8RhKoOY/5FHuoMKhn+RTa5zRX3EHrgI2u0ScjoZw==",
+      "peer": true,
       "requires": {
         "tslib": "^1.13.0"
       },
@@ -14507,7 +14608,8 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "peer": true
         }
       }
     },
@@ -14515,6 +14617,7 @@
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-1.5.3.tgz",
       "integrity": "sha512-K45GaTgkJ1ojw3YCK1fye3bN03OwG448oOvyQrFmu1XMHwycTgexGTabUuq2EitghYesOI4CaLF/8zdusiVgsQ==",
+      "peer": true,
       "requires": {
         "@esri/arcgis-html-sanitizer": "3.0.0",
         "@types/lodash.isplainobject": "^4.0.7",
@@ -14528,19 +14631,22 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "peer": true
         }
       }
     },
     "@floating-ui/core": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.1.tgz",
-      "integrity": "sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA=="
+      "integrity": "sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA==",
+      "peer": true
     },
     "@floating-ui/dom": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.3.tgz",
       "integrity": "sha512-6H1kwjkOZKabApNtXRiYHvMmYJToJ1DV7rQ3xc/WJpOABhQIOJJOdz2AOejj8X+gcybaFmBpisVTZxBZAM3V0w==",
+      "peer": true,
       "requires": {
         "@floating-ui/core": "^1.0.1"
       }
@@ -15344,7 +15450,8 @@
     "@types/arcgis-js-api": {
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/@types/arcgis-js-api/-/arcgis-js-api-4.24.0.tgz",
-      "integrity": "sha512-Qh6Yw1g4cBq1UGoX1xI+G+4NgxZgTgmSj6IdV8CE9k7IRdPOZIHeEC5ZHDjf93mgjbD8vytPZWHVvcYs1F/PDw=="
+      "integrity": "sha512-Qh6Yw1g4cBq1UGoX1xI+G+4NgxZgTgmSj6IdV8CE9k7IRdPOZIHeEC5ZHDjf93mgjbD8vytPZWHVvcYs1F/PDw==",
+      "dev": true
     },
     "@types/babel__core": {
       "version": "7.1.16",
@@ -15566,12 +15673,14 @@
     "@types/lodash": {
       "version": "4.14.184",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.184.tgz",
-      "integrity": "sha512-RoZphVtHbxPZizt4IcILciSWiC6dcn+eZ8oX9IWEYfDMcocdd42f7NPI6fQj+6zI8y4E0L7gu2pcZKLGTRaV9Q=="
+      "integrity": "sha512-RoZphVtHbxPZizt4IcILciSWiC6dcn+eZ8oX9IWEYfDMcocdd42f7NPI6fQj+6zI8y4E0L7gu2pcZKLGTRaV9Q==",
+      "peer": true
     },
     "@types/lodash.isplainobject": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/@types/lodash.isplainobject/-/lodash.isplainobject-4.0.7.tgz",
       "integrity": "sha512-fdHtdjpy7fXydEaRHx1dPa+2AVmLbmk2Gv7f0w/90BKCH0DkWo8pIrzygnB3rvgo6oKNb3cO9VaPpj9GLCr5Ug==",
+      "peer": true,
       "requires": {
         "@types/lodash": "*"
       }
@@ -15857,6 +15966,7 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
       "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+      "peer": true,
       "requires": {
         "esm": "^3.2.25"
       }
@@ -16177,6 +16287,7 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
       "integrity": "sha512-0l7mVU+LrQ2X/ZTUq63T5i3VyR2aTgcRTFmBcD6djQ/Fek6q1A9t5u0F4jZVYHzp78jwWAzGfLpAY1b4/I3lfg==",
+      "peer": true,
       "requires": {
         "babel-runtime": "^6.22.0",
         "core-js": "^2.4.0",
@@ -16217,6 +16328,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
+      "peer": true,
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -16225,7 +16337,8 @@
         "regenerator-runtime": {
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "peer": true
         }
       }
     },
@@ -16901,7 +17014,8 @@
     "core-js": {
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+      "peer": true
     },
     "core-util-is": {
       "version": "1.0.3",
@@ -17260,6 +17374,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "peer": true,
       "requires": {
         "iconv-lite": "^0.6.2"
       },
@@ -17268,6 +17383,7 @@
           "version": "0.6.3",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
           "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "peer": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
@@ -17698,7 +17814,8 @@
     "esm": {
       "version": "3.2.25",
       "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "peer": true
     },
     "espree": {
       "version": "9.3.1",
@@ -18062,6 +18179,7 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.2.4.tgz",
       "integrity": "sha512-19R4aaHzqsTe7gyL3wthWiyYyNFqVK1tzO6BMEAQEKRu4R3ptkl4FyuEtUMOPKdYsO6k6C/Ym3YJ6eCL49OdSw==",
+      "peer": true,
       "requires": {
         "he": "~1.1.1",
         "nimnjs": "^1.1.0",
@@ -18474,6 +18592,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+      "peer": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       },
@@ -18481,7 +18600,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
+          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+          "peer": true
         }
       }
     },
@@ -18579,7 +18699,8 @@
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha512-z/GDPjlRMNOa2XJiB4em8wJpuuBfrFOlYKTZxtpkdr1uPdibHI8rYA3MY0KDObpVyaes0e/aunid/t88ZI2EKA=="
+      "integrity": "sha512-z/GDPjlRMNOa2XJiB4em8wJpuuBfrFOlYKTZxtpkdr1uPdibHI8rYA3MY0KDObpVyaes0e/aunid/t88ZI2EKA==",
+      "peer": true
     },
     "hosted-git-info": {
       "version": "2.8.9",
@@ -18658,7 +18779,8 @@
     "immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "peer": true
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -20631,7 +20753,8 @@
     "json-typescript": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/json-typescript/-/json-typescript-1.1.2.tgz",
-      "integrity": "sha512-Np07MUsYMKbB0nNlw/MMIRjUK7ehO48LA4FsrzrhCfTUxMKbvOBAo0sc0b4nQ80ge9d32sModCunCgoyUojgUA=="
+      "integrity": "sha512-Np07MUsYMKbB0nNlw/MMIRjUK7ehO48LA4FsrzrhCfTUxMKbvOBAo0sc0b4nQ80ge9d32sModCunCgoyUojgUA==",
+      "peer": true
     },
     "json5": {
       "version": "2.2.0",
@@ -20646,6 +20769,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/jsonapi-typescript/-/jsonapi-typescript-0.1.3.tgz",
       "integrity": "sha512-uPcPS01GeM+4HIyn18s7l1yD2S3uLZy2TX1UkQffCM0bLb3TMwudXUyVXPHTMZ4vdZT8MqKqN2vjB5PogTAdFQ==",
+      "peer": true,
       "requires": {
         "json-typescript": "^1.0.0"
       }
@@ -20664,6 +20788,7 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
       "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "peer": true,
       "requires": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
@@ -20721,6 +20846,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
       "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "peer": true,
       "requires": {
         "immediate": "~3.0.5"
       }
@@ -21027,17 +21153,20 @@
     "nimn_schema_builder": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/nimn_schema_builder/-/nimn_schema_builder-1.1.0.tgz",
-      "integrity": "sha512-DK5/B8CM4qwzG2URy130avcwPev4uO0ev836FbQyKo1ms6I9z/i6EJyiZ+d9xtgloxUri0W+5gfR8YbPq7SheA=="
+      "integrity": "sha512-DK5/B8CM4qwzG2URy130avcwPev4uO0ev836FbQyKo1ms6I9z/i6EJyiZ+d9xtgloxUri0W+5gfR8YbPq7SheA==",
+      "peer": true
     },
     "nimn-date-parser": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/nimn-date-parser/-/nimn-date-parser-1.0.0.tgz",
-      "integrity": "sha512-1Nf+x3EeMvHUiHsVuEhiZnwA8RMeOBVTQWfB1S2n9+i6PYCofHd2HRMD+WOHIHYshy4T4Gk8wQoCol7Hq3av8Q=="
+      "integrity": "sha512-1Nf+x3EeMvHUiHsVuEhiZnwA8RMeOBVTQWfB1S2n9+i6PYCofHd2HRMD+WOHIHYshy4T4Gk8wQoCol7Hq3av8Q==",
+      "peer": true
     },
     "nimnjs": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/nimnjs/-/nimnjs-1.3.2.tgz",
       "integrity": "sha512-TIOtI4iqkQrUM1tiM76AtTQem0c7e56SkDZ7sj1d1MfUsqRcq2ZWQvej/O+HBTZV7u/VKnwlKTDugK/75IRPPw==",
+      "peer": true,
       "requires": {
         "nimn_schema_builder": "^1.0.0",
         "nimn-date-parser": "^1.0.0"
@@ -21348,6 +21477,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/opencollective/-/opencollective-1.0.3.tgz",
       "integrity": "sha512-YBRI0Qa8+Ui0/STV1qYuPrJm889PT3oCPHMVoL+8Y3nwCffj7PSrB2NlGgrhgBKDujxTjxknHWJ/FiqOsYcIDw==",
+      "peer": true,
       "requires": {
         "babel-polyfill": "6.23.0",
         "chalk": "1.1.3",
@@ -21360,22 +21490,26 @@
         "ansi-escapes": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-          "integrity": "sha512-wiXutNjDUlNEDWHcYH3jtZUhd3c4/VojassD8zHdHCY13xbZy2XbW+NKQwA0tWGBVzDA9qEzYwfoSsWmviidhw=="
+          "integrity": "sha512-wiXutNjDUlNEDWHcYH3jtZUhd3c4/VojassD8zHdHCY13xbZy2XbW+NKQwA0tWGBVzDA9qEzYwfoSsWmviidhw==",
+          "peer": true
         },
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
+          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+          "peer": true
         },
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA=="
+          "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+          "peer": true
         },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+          "peer": true,
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -21387,12 +21521,14 @@
         "chardet": {
           "version": "0.4.2",
           "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-          "integrity": "sha512-j/Toj7f1z98Hh2cYo2BVr85EpIRWqUi7rtRSGxh/cqUjqrnJe9l9UE7IUGd2vQ2p+kSHLkSzObQPZPLUC6TQwg=="
+          "integrity": "sha512-j/Toj7f1z98Hh2cYo2BVr85EpIRWqUi7rtRSGxh/cqUjqrnJe9l9UE7IUGd2vQ2p+kSHLkSzObQPZPLUC6TQwg==",
+          "peer": true
         },
         "cli-cursor": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
           "integrity": "sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==",
+          "peer": true,
           "requires": {
             "restore-cursor": "^2.0.0"
           }
@@ -21400,12 +21536,14 @@
         "cli-width": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
-          "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw=="
+          "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
+          "peer": true
         },
         "external-editor": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
           "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+          "peer": true,
           "requires": {
             "chardet": "^0.4.0",
             "iconv-lite": "^0.4.17",
@@ -21416,6 +21554,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
           "integrity": "sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==",
+          "peer": true,
           "requires": {
             "escape-string-regexp": "^1.0.5"
           }
@@ -21424,6 +21563,7 @@
           "version": "3.0.6",
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.0.6.tgz",
           "integrity": "sha512-thluxTGBXUGb8DuQcvH9/CM/CrcGyB5xUpWc9x6Slqcq1z/hRr2a6KxUpX4ddRfmbe0hg3E4jTvo5833aWz3BA==",
+          "peer": true,
           "requires": {
             "ansi-escapes": "^1.1.0",
             "chalk": "^1.0.0",
@@ -21443,32 +21583,38 @@
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w=="
+          "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
+          "peer": true
         },
         "is-stream": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="
+          "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+          "peer": true
         },
         "mimic-fn": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+          "peer": true
         },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha512-7Wl+Jz+IGWuSdgsQEJ4JunV0si/iMhg42MnQQG6h1R6TNeVenp4U9x5CC5v/gYqz/fENLQITAWXidNtVL0NNbw=="
+          "integrity": "sha512-7Wl+Jz+IGWuSdgsQEJ4JunV0si/iMhg42MnQQG6h1R6TNeVenp4U9x5CC5v/gYqz/fENLQITAWXidNtVL0NNbw==",
+          "peer": true
         },
         "mute-stream": {
           "version": "0.0.7",
           "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-          "integrity": "sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ=="
+          "integrity": "sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ==",
+          "peer": true
         },
         "node-fetch": {
           "version": "1.6.3",
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
           "integrity": "sha512-BDxbhLHXFFFvilHjh9xihcDyPkXQ+kjblxnl82zAX41xUYSNvuRpFRznmldR9+OKu+p+ULZ7hNoyunlLB5ecUA==",
+          "peer": true,
           "requires": {
             "encoding": "^0.1.11",
             "is-stream": "^1.0.1"
@@ -21478,6 +21624,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
           "integrity": "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==",
+          "peer": true,
           "requires": {
             "mimic-fn": "^1.0.0"
           }
@@ -21486,6 +21633,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
           "integrity": "sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==",
+          "peer": true,
           "requires": {
             "onetime": "^2.0.0",
             "signal-exit": "^3.0.2"
@@ -21495,6 +21643,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "peer": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^4.0.0"
@@ -21503,12 +21652,14 @@
             "ansi-regex": {
               "version": "3.0.1",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
-              "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw=="
+              "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
+              "peer": true
             },
             "strip-ansi": {
               "version": "4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
+              "peer": true,
               "requires": {
                 "ansi-regex": "^3.0.0"
               }
@@ -21519,6 +21670,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+          "peer": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -21526,7 +21678,8 @@
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g=="
+          "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+          "peer": true
         }
       }
     },
@@ -21534,6 +21687,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
       "integrity": "sha512-iPBWbPP4OEOzR1xfhpGLDh+ypKBOygunZhM9jBtA7FS5sKjEiMZw0EFb82hnDOmTZX90ZWLoZKUza4cVt8MexA==",
+      "peer": true,
       "requires": {
         "object-assign": "^4.0.1",
         "pinkie-promise": "^2.0.0"
@@ -21690,7 +21844,8 @@
     "pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "peer": true
     },
     "parent-module": {
       "version": "1.0.1",
@@ -21782,12 +21937,14 @@
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg=="
+      "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
+      "peer": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
+      "peer": true,
       "requires": {
         "pinkie": "^2.0.0"
       }
@@ -22205,7 +22362,8 @@
     "regenerator-runtime": {
       "version": "0.10.5",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-      "integrity": "sha512-02YopEIhAgiBHWeoTiA8aitHDt8z6w+rQqNuIftlM+ZtvSl/brTouaU7DW6GO/cHtvxJvS4Hwv2ibKdxIRi24w=="
+      "integrity": "sha512-02YopEIhAgiBHWeoTiA8aitHDt8z6w+rQqNuIftlM+ZtvSl/brTouaU7DW6GO/cHtvxJvS4Hwv2ibKdxIRi24w==",
+      "peer": true
     },
     "regex-not": {
       "version": "1.0.2",
@@ -22407,7 +22565,8 @@
     "rx": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-      "integrity": "sha512-CiaiuN6gapkdl+cZUr67W6I8jquN4lkak3vtIsIWCl4XIPP8ffsoyN6/+PuGXnQy8Cu8W2y9Xxh31Rq4M6wUug=="
+      "integrity": "sha512-CiaiuN6gapkdl+cZUr67W6I8jquN4lkak3vtIsIWCl4XIPP8ffsoyN6/+PuGXnQy8Cu8W2y9Xxh31Rq4M6wUug==",
+      "peer": true
     },
     "rxjs": {
       "version": "7.4.0",
@@ -22762,7 +22921,8 @@
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "peer": true
     },
     "shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@stencil/postcss": "^2.1.0",
     "@stencil/sass": "^2.0.0",
     "@stencil/store": "^2.0.1",
+    "@types/arcgis-js-api": "^4.24.0",
     "@types/jest": "^27.0.3",
     "@types/node": "^16.11.11",
     "@types/puppeteer": "^5.4.2",
@@ -66,19 +67,20 @@
   },
   "dependencies": {
     "@arcgis/core": "^4.24.7",
+    "minimist": "^1.2.6"
+  },
+  "peerDependencies": {
     "@esri/arcgis-rest-auth": "^3.4.2",
     "@esri/arcgis-rest-feature-layer": "^3.4.2",
     "@esri/arcgis-rest-portal": "^3.4.2",
     "@esri/arcgis-rest-request": "^3.4.2",
     "@esri/arcgis-rest-service-admin": "^3.4.2",
-    "@esri/calcite-components": "1.0.0-beta.97",
     "@esri/hub-common": "9.29.0",
     "@esri/hub-initiatives": "9.29.0",
     "@esri/hub-sites": "9.29.0",
     "@esri/hub-teams": "9.29.0",
     "@esri/solution-common": "1.5.3",
-    "@types/arcgis-js-api": "^4.24.0",
-    "minimist": "^1.2.6"
+    "@esri/calcite-components": "1.0.0-beta.97"
   },
   "repository": {
     "type": "git",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -361,7 +361,7 @@ export namespace Components {
         /**
           * Contains the current solution item id
          */
-        "solutionItemId": any;
+        "solutionItemId": string;
         "unloadSolution": () => Promise<void>;
     }
     interface SolutionContents {
@@ -1049,7 +1049,7 @@ declare namespace LocalJSX {
         /**
           * Contains the current solution item id
          */
-        "solutionItemId"?: any;
+        "solutionItemId"?: string;
     }
     interface SolutionContents {
         "onSolutionItemSelected"?: (event: SolutionContentsCustomEvent<string>) => void;

--- a/src/components/solution-configuration/readme.md
+++ b/src/components/solution-configuration/readme.md
@@ -11,7 +11,7 @@
 | ---------------- | ------------------ | ------------------------------------- | ------------- | ----------- |
 | `authentication` | --                 | Credentials for requests              | `UserSession` | `undefined` |
 | `showLoading`    | `show-loading`     | Used to show/hide loading indicator   | `boolean`     | `false`     |
-| `solutionItemId` | `solution-item-id` | Contains the current solution item id | `any`         | `undefined` |
+| `solutionItemId` | `solution-item-id` | Contains the current solution item id | `string`      | `""`        |
 
 
 ## Methods

--- a/src/components/solution-configuration/solution-configuration.tsx
+++ b/src/components/solution-configuration/solution-configuration.tsx
@@ -52,17 +52,10 @@ export class SolutionConfiguration {
   /**
    * Contains the current solution item id
    */
-  @Prop({ mutable: true, reflect: true }) solutionItemId;
+  @Prop({ mutable: true, reflect: true }) solutionItemId = "";
 
   @Watch("solutionItemId") async valueWatchHandler(): Promise<void> {
-    if (this.solutionItemId) {
-      this._solutionIsLoaded = false;
-      await state.loadSolution(this.solutionItemId, this.authentication);
-      this._initProps();
-      this._solutionIsLoaded = true;
-    } else {
-      this._reset();
-    }
+    await this._loadSolution(this.solutionItemId);
   }
 
   /**
@@ -77,6 +70,8 @@ export class SolutionConfiguration {
   //--------------------------------------------------------------------------
 
   constructor() {
+    void this._loadSolution(this.solutionItemId);
+
     window.addEventListener("solutionStoreHasChanges",
       (evt) => {
         this._updateSaveability(
@@ -324,6 +319,8 @@ export class SolutionConfiguration {
 
   /**
    * Set Props with the initial values
+   *
+   * @protected
    */
   protected _initProps(): void {
     const solutionData = state.getStoreInfo("solutionData");
@@ -346,7 +343,30 @@ export class SolutionConfiguration {
   }
 
   /**
+   * Loads a solution.
+   *
+   * @param solutionItemId AGO id of solution to load
+   *
+   * @returns Resolved promise when task is done
+   *
+   * @protected
+   */
+  protected async _loadSolution(solutionItemId: string): Promise<void> {
+    if (solutionItemId) {
+      this._solutionIsLoaded = false;
+      await state.loadSolution(solutionItemId, this.authentication);
+      this._initProps();
+      this._solutionIsLoaded = true;
+    } else {
+      this._reset();
+    }
+    return Promise.resolve();
+  }
+
+  /**
    * Resets internal variables.
+   *
+   * @protected
    */
   protected _reset(): void {
     this._currentEditItemId = "";
@@ -356,7 +376,9 @@ export class SolutionConfiguration {
   }
 
   /**
-   * Toggle _treeOpen prop to show/hide content tree
+   * Toggle _treeOpen prop to show/hide content tree.
+   *
+   * @protected
    */
   protected _toggleTree(): void {
     this._treeOpen = !this._treeOpen;
@@ -369,6 +391,8 @@ export class SolutionConfiguration {
    * @param solutionStoreHasChanges Are there changes in the configuration editor's internal store?
    * @param solutionEditorHasChanges Are there changes in the configuration editor's JSON editor?
    * @param solutionEditorHasErrors Are there errors in the configuration editor's JSON editor?
+   *
+   * @protected
    */
   protected _updateSaveability(
     solutionStoreHasChanges: boolean,

--- a/src/demos/new-solution-configuration.html
+++ b/src/demos/new-solution-configuration.html
@@ -20,7 +20,7 @@
    | limitations under the License.
   -->
 
-  <link rel="stylesheet" href="https://js.arcgis.com/calcite-components/1.0.0-beta.94/calcite.css" type="text/css" />
+  <link rel="stylesheet" href="https://js.arcgis.com/calcite-components/1.0.0-beta.97/calcite.css" type="text/css" />
   <link rel="stylesheet" href="https://webapps-cdn.esri.com/CDN/fonts/v1.4.1/fonts.css" />
   <link rel="stylesheet" href="../solutions.css" type="text/css">
   <style>
@@ -76,7 +76,7 @@
   <script src="https://unpkg.com/@esri/arcgis-rest-auth@3.5.0/dist/umd/auth.umd.min.js"></script>
   <script src="https://unpkg.com/@esri/arcgis-rest-portal@3.5.0/dist/umd/portal.umd.min.js"></script>
   <script src="https://unpkg.com/@esri/solution-common@1.5.0/dist/umd/common.umd.min.js"></script>
-  <script type="module" src="https://js.arcgis.com/calcite-components/1.0.0-beta.94/calcite.esm.js"></script>
+  <script type="module" src="https://js.arcgis.com/calcite-components/1.0.0-beta.97/calcite.esm.js"></script>
   <script type="module" src="../solutions.esm.js"></script>
 </head>
 


### PR DESCRIPTION
While using the `solution-configuration` component in the `solution-creation-app`, was getting a problem where the watch handler was not getting run because the solution id had been set before the constructor was run, and so no change was detected.

And
* Switched to peer dependencies
* Updated calcite-components to 1.0.0-beta.97