### PR TITLE
Be sure that translations are available during rendering

### DIFF
--- a/src/components/solution-configuration/solution-configuration.tsx
+++ b/src/components/solution-configuration/solution-configuration.tsx
@@ -107,6 +107,11 @@ export class SolutionConfiguration {
   render(): VNode {
     const wkid = getProp(state.getStoreInfo("spatialReferenceInfo"), "spatialReference");
     const hasServices: boolean = state.getStoreInfo("featureServices").length > 0;
+
+    const solutionData = state.getStoreInfo("solutionData");
+    this._solutionVariables = JSON.stringify(utils.getSolutionVariables(solutionData.templates, this._translations));
+    this._organizationVariables = JSON.stringify(utils.getOrganizationVariables(this._translations));
+
     return (
       <Host>
         {
@@ -324,9 +329,6 @@ export class SolutionConfiguration {
    */
   protected _initProps(): void {
     const solutionData = state.getStoreInfo("solutionData");
-
-    this._solutionVariables = JSON.stringify(utils.getSolutionVariables(solutionData.templates, this._translations));
-    this._organizationVariables = JSON.stringify(utils.getOrganizationVariables(this._translations));
 
     this._templateHierarchy = [...utils.getInventoryItems(solutionData.templates)];
 

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -28,11 +28,14 @@ export const config: Config = {
         { src: 'utils' }
       ]
     },
-    { type: "dist-custom-elements", autoDefineCustomElements: true },
     {
       type: 'docs-readme'
     },
-    { type: "custom", name: "preact", generator: generatePreactTypes },
+    {
+       type: "custom",
+       name: "preact",
+       generator: generatePreactTypes
+    },
   ],
   plugins: [
     sass({

--- a/stencil.debugconfig.ts
+++ b/stencil.debugconfig.ts
@@ -28,11 +28,14 @@ export const config: Config = {
         { src: 'utils' }
       ]
     },
-    { type: "dist-custom-elements", autoDefineCustomElements: true },
     {
       type: 'docs-readme'
     },
-    { type: "custom", name: "preact", generator: generatePreactTypes },
+    {
+       type: "custom",
+       name: "preact",
+       generator: generatePreactTypes
+    },
   ],
   plugins: [
     sass({


### PR DESCRIPTION
When the app is first used after a lull, it sometimes crashes because the variables translations are not defined. This might be due to a timing problem when the translations are not cached by their server and thus are not returned fast enough.

With this PR, the calls to extract the variables are moved to the `render` function.

Also removed unused `dist-custom-elements` StencilJS configuration element.