### PR TITLE
Rearrange calls to be sure item info is available with slow network connections

### DIFF
--- a/src/components/solution-item-details/solution-item-details.tsx
+++ b/src/components/solution-item-details/solution-item-details.tsx
@@ -132,7 +132,7 @@ export class SolutionItemDetails {
   }
 
   componentDidRender(): void {
-    this._loadThumb()
+    this._loadThumb();
   }
 
   //--------------------------------------------------------------------------

--- a/src/components/solution-item-details/solution-item-details.tsx
+++ b/src/components/solution-item-details/solution-item-details.tsx
@@ -48,9 +48,6 @@ export class SolutionItemDetails {
    */
   @Prop({ mutable: true, reflect: true }) itemId = "";
 
-  @Watch("itemId") itemIdWatchHandler(): void {
-  }
-
   //--------------------------------------------------------------------------
   //
   //  Lifecycle

--- a/src/components/solution-item-details/solution-item-details.tsx
+++ b/src/components/solution-item-details/solution-item-details.tsx
@@ -49,9 +49,6 @@ export class SolutionItemDetails {
   @Prop({ mutable: true, reflect: true }) itemId = "";
 
   @Watch("itemId") itemIdWatchHandler(): void {
-    this.itemEdit = state.getItemInfo(this.itemId);
-    this.itemDetails = this.itemEdit.item;
-    this.itemType = this.itemDetails.type;
   }
 
   //--------------------------------------------------------------------------
@@ -67,8 +64,13 @@ export class SolutionItemDetails {
     return this._getTranslations();
   }
 
-  componentDidRender(): void {
-    this._loadThumb()
+  async componentWillRender(): Promise<void> {
+    this.itemEdit = state.getItemInfo(this.itemId);
+    if (this.itemEdit) {
+      this.itemDetails = this.itemEdit.item;
+      this.itemType = this.itemDetails.type;
+    }
+    return Promise.resolve();
   }
 
   /**
@@ -130,6 +132,10 @@ export class SolutionItemDetails {
         </div>
       </Host>
     );
+  }
+
+  componentDidRender(): void {
+    this._loadThumb()
   }
 
   //--------------------------------------------------------------------------


### PR DESCRIPTION
With slower servers (e.g., ec2), when one went to configure a solution's items, the details for the first item in the solution weren't being displayed. This PR tries to fix the timing so that the first item details are always displayed.