### PR TITLE
Provide alternate format for authorization

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -349,11 +349,12 @@ export namespace Components {
     }
     interface SolutionConfiguration {
         /**
-          * Credentials for requests
+          * Credentials for requests, which can be a serialized UserSession
          */
         "authentication": UserSession;
         "getSpatialReferenceInfo": () => Promise<ISolutionSpatialReferenceInfo>;
         "saveSolution": () => Promise<void>;
+        "serializedAuthentication": string;
         /**
           * Used to show/hide loading indicator
          */
@@ -1039,9 +1040,10 @@ declare namespace LocalJSX {
     }
     interface SolutionConfiguration {
         /**
-          * Credentials for requests
+          * Credentials for requests, which can be a serialized UserSession
          */
         "authentication"?: UserSession;
+        "serializedAuthentication"?: string;
         /**
           * Used to show/hide loading indicator
          */

--- a/src/components/solution-configuration/readme.md
+++ b/src/components/solution-configuration/readme.md
@@ -7,11 +7,12 @@
 
 ## Properties
 
-| Property         | Attribute          | Description                           | Type          | Default               |
-| ---------------- | ------------------ | ------------------------------------- | ------------- | --------------------- |
-| `authentication` | --                 | Credentials for requests              | `UserSession` | `new UserSession({})` |
-| `showLoading`    | `show-loading`     | Used to show/hide loading indicator   | `boolean`     | `false`               |
-| `solutionItemId` | `solution-item-id` | Contains the current solution item id | `string`      | `""`                  |
+| Property                   | Attribute                   | Description                                                     | Type          | Default               |
+| -------------------------- | --------------------------- | --------------------------------------------------------------- | ------------- | --------------------- |
+| `authentication`           | --                          | Credentials for requests, which can be a serialized UserSession | `UserSession` | `new UserSession({})` |
+| `serializedAuthentication` | `serialized-authentication` |                                                                 | `string`      | `""`                  |
+| `showLoading`              | `show-loading`              | Used to show/hide loading indicator                             | `boolean`     | `false`               |
+| `solutionItemId`           | `solution-item-id`          | Contains the current solution item id                           | `string`      | `""`                  |
 
 
 ## Methods

--- a/src/components/solution-configuration/solution-configuration.tsx
+++ b/src/components/solution-configuration/solution-configuration.tsx
@@ -54,6 +54,8 @@ export class SolutionConfiguration {
   @Watch("serializedAuthentication") async serializedAuthenticationWatchHandler(): Promise<void> {
     if (this.serializedAuthentication) {
       this.authentication = UserSession.deserialize(this.serializedAuthentication);
+    } else {
+      this.authentication = new UserSession({});
     }
   }
 

--- a/src/components/solution-configuration/solution-configuration.tsx
+++ b/src/components/solution-configuration/solution-configuration.tsx
@@ -45,9 +45,17 @@ export class SolutionConfiguration {
   //--------------------------------------------------------------------------
 
   /**
-   * Credentials for requests
+   * Credentials for requests, which can be a serialized UserSession
    */
   @Prop({ mutable: true }) authentication = new UserSession({});
+
+  @Prop({ mutable: true }) serializedAuthentication = "";
+
+  @Watch("serializedAuthentication") async serializedAuthenticationWatchHandler(): Promise<void> {
+    if (this.serializedAuthentication) {
+      this.authentication = UserSession.deserialize(this.serializedAuthentication);
+    }
+  }
 
   /**
    * Contains the current solution item id
@@ -70,6 +78,10 @@ export class SolutionConfiguration {
   //--------------------------------------------------------------------------
 
   constructor() {
+    if (this.serializedAuthentication) {
+      this.authentication = UserSession.deserialize(this.serializedAuthentication);
+    }
+
     void this._loadSolution(this.solutionItemId);
 
     window.addEventListener("solutionStoreHasChanges",

--- a/src/components/solution-configuration/solution-configuration.tsx
+++ b/src/components/solution-configuration/solution-configuration.tsx
@@ -52,11 +52,7 @@ export class SolutionConfiguration {
   @Prop({ mutable: true }) serializedAuthentication = "";
 
   @Watch("serializedAuthentication") async serializedAuthenticationWatchHandler(): Promise<void> {
-    if (this.serializedAuthentication) {
-      this.authentication = UserSession.deserialize(this.serializedAuthentication);
-    } else {
-      this.authentication = new UserSession({});
-    }
+    this.authentication = this.serializedAuthentication ? UserSession.deserialize(this.serializedAuthentication) : new UserSession({});
   }
 
   /**


### PR DESCRIPTION
Allow for authentication to be provided via a string containing a serialized `UserSession`.  This is useful for working with strictly-typed languages such as Elm.