### PR TITLE
import esm style

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -270,7 +270,7 @@ export namespace Components {
         /**
           * esri/geometry: https://developers.arcgis.com/javascript/latest/api-reference/esri-geometry.html
          */
-        "geometries": __esri.Geometry[];
+        "geometries": Geometry[];
         /**
           * Get the new selection set
           * @returns Promise with the new selection set
@@ -1139,7 +1139,7 @@ declare namespace LocalJSX {
         /**
           * esri/geometry: https://developers.arcgis.com/javascript/latest/api-reference/esri-geometry.html
          */
-        "geometries"?: __esri.Geometry[];
+        "geometries"?: Geometry[];
         /**
           * boolean: When true a new label is not generated for the stored selection set
          */

--- a/src/components/buffer-tools/buffer-tools.tsx
+++ b/src/components/buffer-tools/buffer-tools.tsx
@@ -15,9 +15,9 @@
  */
 
 import { Component, Element, Event, EventEmitter, Host, h, Prop, State, VNode, Watch } from "@stencil/core";
-import { loadModules } from "../../utils/loadModules";
 import BufferTools_T9n from "../../assets/t9n/buffer-tools/resources.json";
 import { getLocaleComponentStrings } from "../../utils/locale";
+import * as geometryEngine from "@arcgis/core/geometry/geometryEngine";
 
 @Component({
   tag: "buffer-tools",
@@ -102,11 +102,6 @@ export class BufferTools {
   protected _bufferTimeout: NodeJS.Timeout;
 
   /**
-   * geometryEngine: https://developers.arcgis.com/javascript/latest/api-reference/esri-geometry-geometryEngine.html
-   */
-  protected _geometryEngine: __esri.geometryEngine;
-
-  /**
    * HTMLCalciteSelectElement: The html element for selecting buffer unit
    */
   protected _unitElement: HTMLCalciteSelectElement;
@@ -159,7 +154,6 @@ export class BufferTools {
    */
   async componentWillLoad(): Promise<void> {
     await this._getTranslations();
-    await this._initModules();
   }
 
   /**
@@ -178,22 +172,6 @@ export class BufferTools {
   //  Functions (protected)
   //
   //--------------------------------------------------------------------------
-
-  /**
-   * Load esri javascript api modules
-   *
-   * @returns Promise resolving when function is done
-   *
-   * @protected
-   */
-  protected async _initModules(): Promise<void> {
-    const [geometryEngine]: [
-      __esri.geometryEngine
-    ] = await loadModules([
-      "esri/geometry/geometryEngine"
-    ]);
-    this._geometryEngine = geometryEngine;
-  }
 
   /**
    * Gets the nodes for each of the possible distance units
@@ -257,7 +235,7 @@ export class BufferTools {
     this._bufferTimeout = setTimeout(() => {
       // needs to be wgs 84 or Web Mercator
       if (this.geometries?.length > 0 && this.unit && this.distance > 0) {
-        const buffer = this._geometryEngine.geodesicBuffer(
+        const buffer = geometryEngine.geodesicBuffer(
           this.geometries,
           this.distance,
           this.unit,

--- a/src/components/buffer-tools/test/buffer-tools.spec.tsx
+++ b/src/components/buffer-tools/test/buffer-tools.spec.tsx
@@ -18,7 +18,6 @@ import { h } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
 import { BufferTools } from '../buffer-tools';
 import * as locale from "../../../utils/locale";
-import * as loadModules from "../../../utils/loadModules";
 import * as translations from "../../../assets/t9n/buffer-tools/resources.json";
 
 jest.setTimeout(30000);
@@ -31,10 +30,6 @@ beforeEach(() => {
   jest.spyOn(locale, "getLocaleComponentStrings").mockImplementation(() => [
     translations
   ] as any);
-
-  jest.spyOn(loadModules, "loadModules").mockImplementation(async () => {
-    return [{ geodesicBuffer: () => {}}]
-  });
 
   jest.useFakeTimers();
 

--- a/src/components/map-card/map-card.tsx
+++ b/src/components/map-card/map-card.tsx
@@ -15,10 +15,11 @@
  */
 
 import { Component, Element, Event, EventEmitter, Host, h, Prop, State, VNode, Watch } from '@stencil/core';
-import { loadModules } from "../../utils/loadModules";
 import MapCard_T9n from "../../assets/t9n/map-card/resources.json";
 import { getLocaleComponentStrings } from "../../utils/locale";
 import { EExpandType, IMapInfo } from "../../utils/interfaces";
+import WebMap from "@arcgis/core/WebMap";
+import MapView from "@arcgis/core/views/MapView";
 
 // TODO navigation and accessability isn't right for the map list
 //   tab does not go into the list when it's open
@@ -96,16 +97,6 @@ export class MapCard {
    */
   protected _mapDivId = "map-div";
 
-  /**
-   * esri/views/MapView: https://developers.arcgis.com/javascript/latest/api-reference/esri-views-MapView.html
-   */
-  protected MapView: typeof __esri.MapView;
-
-  /**
-   * esri/WebMap: https://developers.arcgis.com/javascript/latest/api-reference/esri-WebMap.html
-   */
-  protected WebMap: typeof __esri.WebMap;
-
   //--------------------------------------------------------------------------
   //
   //  Watch handlers
@@ -160,7 +151,6 @@ export class MapCard {
    */
   async componentWillLoad(): Promise<void> {
     await this._getTranslations();
-    await this._initModules();
   }
 
   /**
@@ -189,25 +179,6 @@ export class MapCard {
   //  Functions (protected)
   //
   //--------------------------------------------------------------------------
-
-  /**
-   * Load esri javascript api modules
-   *
-   * @returns Promise resolving when function is done
-   *
-   * @protected
-   */
-  protected async _initModules(): Promise<void> {
-    const [WebMap, MapView]: [
-      __esri.WebMapConstructor,
-      __esri.MapViewConstructor
-    ] = await loadModules([
-      "esri/WebMap",
-      "esri/views/MapView"
-    ]);
-    this.WebMap = WebMap;
-    this.MapView = MapView;
-  }
 
   /**
    * Create the toolbar (controls used for map and app interactions)
@@ -249,11 +220,11 @@ export class MapCard {
       id = this.mapInfos[0].id;
     }
     if (this._loadedId !== id) {
-      const webMap = new this.WebMap({
+      const webMap = new WebMap({
         portalItem: { id }
       });
 
-      this._mapView = new this.MapView({
+      this._mapView = new MapView({
         container: this._mapDivId,
         map: webMap,
         // TODO consider this more...seems to cause less overflow issues when the component is resized

--- a/src/components/map-draw-tools/map-draw-tools.tsx
+++ b/src/components/map-draw-tools/map-draw-tools.tsx
@@ -15,10 +15,11 @@
  */
 
 import { Component, Element, Event, EventEmitter, Host, h, Method, Prop, State, VNode, Watch } from "@stencil/core";
-import { loadModules } from "../../utils/loadModules";
 import state from "../../utils/publicNotificationStore";
 import MapDrawTools_T9n from "../../assets/t9n/map-draw-tools/resources.json";
 import { getLocaleComponentStrings } from "../../utils/locale";
+import GraphicsLayer from "@arcgis/core/layers/GraphicsLayer";
+import Sketch from "@arcgis/core/widgets/Sketch";
 
 @Component({
   tag: "map-draw-tools",
@@ -93,16 +94,6 @@ export class MapDrawTools {
   //--------------------------------------------------------------------------
 
   /**
-   * esri/layers/GraphicsLayer: https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-GraphicsLayer.html?#constructors-summary
-   */
-  protected GraphicsLayer: typeof __esri.GraphicsLayer;
-
-  /**
-   * esri/widgets/Sketch: https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Sketch.html#constructors-summary
-   */
-  protected Sketch: typeof __esri.Sketch;
-
-  /**
    * The container element for the sketch widget
    */
   protected _sketchElement: HTMLElement;
@@ -110,12 +101,12 @@ export class MapDrawTools {
   /**
    * esri/layers/GraphicsLayer: https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-GraphicsLayer.html
    */
-  protected _sketchGraphicsLayer: __esri.GraphicsLayer;
+  protected _sketchGraphicsLayer: GraphicsLayer;
 
   /**
    * esri/widgets/Sketch: https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Sketch.html
    */
-  protected _sketchWidget: __esri.Sketch;
+  protected _sketchWidget: Sketch;
 
   //--------------------------------------------------------------------------
   //
@@ -187,7 +178,6 @@ export class MapDrawTools {
    */
   async componentWillLoad(): Promise<void> {
     await this._getTranslations();
-    await this._initModules();
   }
 
   /**
@@ -220,25 +210,6 @@ export class MapDrawTools {
   //--------------------------------------------------------------------------
 
   /**
-   * Load esri javascript api modules
-   *
-   * @returns Promise resolving when function is done
-   *
-   * @protected
-   */
-  protected async _initModules(): Promise<void> {
-    const [GraphicsLayer, Sketch]: [
-      __esri.GraphicsLayerConstructor,
-      __esri.SketchConstructor
-    ] = await loadModules([
-      "esri/layers/GraphicsLayer",
-      "esri/widgets/Sketch"
-    ]);
-    this.GraphicsLayer = GraphicsLayer;
-    this.Sketch = Sketch;
-  }
-
-  /**
    * Initialize the graphics layer and the tools that support creating new graphics
    *
    * @protected
@@ -259,9 +230,9 @@ export class MapDrawTools {
     const title = this._translations.sketchLayer;
     const sketchIndex = this.mapView.map.layers.findIndex((l) => l.title === title);
     if (sketchIndex > -1) {
-      this._sketchGraphicsLayer = this.mapView.map.layers.getItemAt(sketchIndex) as __esri.GraphicsLayer;
+      this._sketchGraphicsLayer = this.mapView.map.layers.getItemAt(sketchIndex) as GraphicsLayer;
     } else {
-      this._sketchGraphicsLayer = new this.GraphicsLayer({ title });
+      this._sketchGraphicsLayer = new GraphicsLayer({ title });
       state.managedLayers.push(title);
       this.mapView.map.layers.add(this._sketchGraphicsLayer);
     }
@@ -277,7 +248,7 @@ export class MapDrawTools {
    * @protected
    */
   protected _initDrawTools(): void {
-    this._sketchWidget = new this.Sketch({
+    this._sketchWidget = new Sketch({
       layer: this._sketchGraphicsLayer,
       view: this.mapView,
       container: this._sketchElement,

--- a/src/components/map-draw-tools/test/map-draw-tools.spec.tsx
+++ b/src/components/map-draw-tools/test/map-draw-tools.spec.tsx
@@ -18,7 +18,6 @@ import { h } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
 import { MapDrawTools } from '../map-draw-tools';
 import * as locale from "../../../utils/locale";
-import * as loadModules from "../../../utils/loadModules";
 import * as translations from "../../../assets/t9n/map-draw-tools/resources.json";
 import { GraphicsLayer, Sketch } from "../../../utils/test/mocks/jsApi";
 
@@ -34,10 +33,6 @@ beforeEach(() => {
   jest.spyOn(locale, "getLocaleComponentStrings").mockImplementation(() => [
     translations
   ] as any);
-
-  jest.spyOn(loadModules, "loadModules").mockImplementation(async () => {
-    return [GraphicsLayer, Sketch]
-  });
 
   jest.spyOn(console, 'warn').mockImplementation(() => {});
 

--- a/src/components/map-search/map-search.tsx
+++ b/src/components/map-search/map-search.tsx
@@ -15,10 +15,10 @@
  */
 
 import { Component, Element, Event, EventEmitter, Host, h, Method, Prop, State, VNode } from "@stencil/core";
-import { loadModules } from "../../utils/loadModules";
 import { ISearchResult } from "../../utils/interfaces";
 import MapSearch_T9n from "../../assets/t9n/map-search/resources.json";
 import { getLocaleComponentStrings } from "../../utils/locale";
+import Search from "@arcgis/core/widgets/Search";
 
 @Component({
   tag: "map-search",
@@ -67,11 +67,6 @@ export class MapSearch {
   //  Properties (protected)
   //
   //--------------------------------------------------------------------------
-
-  /**
-   * esri/widgets/Search: https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Search.html
-   */
-  protected Search: typeof __esri.widgetsSearch
 
   /**
    * HTMLElement: The container div for the search widget
@@ -135,7 +130,6 @@ export class MapSearch {
    */
   async componentWillLoad(): Promise<void> {
     await this._getTranslations();
-    await this._initModules();
   }
 
   /**
@@ -163,22 +157,6 @@ export class MapSearch {
   //--------------------------------------------------------------------------
 
   /**
-   * Load esri javascript api modules
-   *
-   * @returns Promise resolving when function is done
-   *
-   * @protected
-   */
-  protected async _initModules(): Promise<void> {
-    const [Search]: [
-      __esri.widgetsSearchConstructor
-    ] = await loadModules([
-      "esri/widgets/Search"
-    ]);
-    this.Search = Search;
-  }
-
-  /**
    * Initialize the search widget
    *
    * @returns Promise resolving when function is done
@@ -200,7 +178,7 @@ export class MapSearch {
         searchTerm: this._searchTerm
       };
 
-      this._searchWidget = new this.Search(searchOptions);
+      this._searchWidget = new Search(searchOptions);
 
       this._searchWidget.on("search-clear", () => {
         this._searchResult = undefined;

--- a/src/components/map-search/test/map-search.spec.tsx
+++ b/src/components/map-search/test/map-search.spec.tsx
@@ -18,9 +18,7 @@ import { h } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
 import { MapSearch } from '../map-search';
 import * as locale from "../../../utils/locale";
-import * as loadModules from "../../../utils/loadModules";
 import * as translations from "../../../assets/t9n/map-search/resources.json";
-import { Search } from "../../../utils/test/mocks/jsApi";
 
 jest.setTimeout(30000);
 
@@ -34,10 +32,6 @@ beforeEach(() => {
   jest.spyOn(locale, "getLocaleComponentStrings").mockImplementation(() => [
     translations
   ] as any);
-
-  jest.spyOn(loadModules, "loadModules").mockImplementation(async () => {
-    return [Search]
-  })
 
   mapView = {
     map: {

--- a/src/components/map-select-tools/test/map-select-tools.spec.tsx
+++ b/src/components/map-select-tools/test/map-select-tools.spec.tsx
@@ -18,7 +18,6 @@ import { h } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
 import { MapSelectTools } from '../map-select-tools';
 import * as locale from "../../../utils/locale";
-import * as loadModules from "../../../utils/loadModules";
 import * as translations from "../../../assets/t9n/map-select-tools/resources.json";
 import { Geometry, geometryEngine, Graphic, GraphicsLayer, LayerView, Search } from "../../../utils/test/mocks/jsApi";
 import * as mapViewUtils from "../../../utils/mapViewUtils";
@@ -39,10 +38,6 @@ beforeEach(() => {
   jest.spyOn(locale, "getLocaleComponentStrings").mockImplementation(() => [
     translations
   ] as any);
-
-  jest.spyOn(loadModules, "loadModules").mockImplementation(async () => {
-    return [GraphicsLayer, Graphic, Search, Geometry, geometryEngine]
-  });
 
   jest.spyOn(mapViewUtils, "highlightFeatures").mockImplementation(async () => {
     return { remove: () => {} } as unknown as any;

--- a/src/components/public-notification/public-notification.tsx
+++ b/src/components/public-notification/public-notification.tsx
@@ -15,7 +15,6 @@
  */
 
 import { Component, Element, Host, h, Listen, Prop, State, VNode, Watch } from "@stencil/core";
-import { loadModules } from "../../utils/loadModules";
 import { EExportType, EPageType, ESketchType, EWorkflowType, ISelectionSet } from "../../utils/interfaces";
 import { goToSelection, getMapLayerView, highlightFeatures } from "../../utils/mapViewUtils";
 import { getSelectionSetQuery } from "../../utils/queryUtils";
@@ -23,6 +22,7 @@ import state from "../../utils/publicNotificationStore";
 import NewPublicNotification_T9n from "../../assets/t9n/public-notification/resources.json";
 import { getLocaleComponentStrings } from "../../utils/locale";
 import * as utils from "../../utils/publicNotificationUtils";
+import * as geometryEngine from "@arcgis/core/geometry/geometryEngine";
 
 @Component({
   tag: "public-notification",
@@ -122,11 +122,6 @@ export class PublicNotification {
    * HTMLPdfDownloadElement: The pdf tools element
    */
   protected _downloadTools: HTMLPdfDownloadElement;
-
-  /**
-   * esri/geometry/geometryEngine: https://developers.arcgis.com/javascript/latest/api-reference/esri-geometry-geometryEngine.html
-   */
-  protected _geometryEngine: __esri.geometryEngine;
 
   /**
    * HTMLCalciteCheckboxElement: When enabled popups will be shown on map click
@@ -237,7 +232,6 @@ export class PublicNotification {
    */
   async componentWillLoad(): Promise<void> {
     await this._getTranslations();
-    await this._initModules();
   }
 
   /**
@@ -265,22 +259,6 @@ export class PublicNotification {
   //  Functions (protected)
   //
   //--------------------------------------------------------------------------
-
-  /**
-   * Load esri javascript api modules
-   *
-   * @returns Promise resolving when function is done
-   *
-   * @protected
-   */
-  protected async _initModules(): Promise<void> {
-    const [geometryEngine]: [
-      __esri.geometryEngine
-    ] = await loadModules([
-      "esri/geometry/geometryEngine"
-    ]);
-    this._geometryEngine = geometryEngine;
-  }
 
   /**
    * Get a calcite action group for the current action
@@ -903,7 +881,7 @@ export class PublicNotification {
     _selectionSets.forEach(selectionSet => {
       selectionSet.layerView = layerView;
       selectionSet.selectedIds = [];
-      oidDefs.push(getSelectionSetQuery(selectionSet, this._geometryEngine));
+      oidDefs.push(getSelectionSetQuery(selectionSet, geometryEngine));
     });
 
     return Promise.all(oidDefs).then(async (results): Promise<void> => {

--- a/src/components/public-notification/test/public-notification.e2e.ts
+++ b/src/components/public-notification/test/public-notification.e2e.ts
@@ -15,8 +15,7 @@
  */
 
 import { newE2EPage } from '@stencil/core/testing';
-import * as locale from "../../../utils/locale";
-import * as loadModules from "../../../utils/loadModules";
+import * as locale from "../../../utils/locale";;
 import * as translations from "../../../assets/t9n/public-notification/resources.json";
 import { geometryEngine } from "../../../utils/test/mocks/jsApi";
 import * as queryUtils from "../../../utils/queryUtils";
@@ -35,10 +34,6 @@ beforeEach(() => {
   jest.spyOn(locale, "getLocaleComponentStrings").mockImplementation(() => [
     translations
   ] as any);
-
-  jest.spyOn(loadModules, "loadModules").mockImplementation(async () => {
-    return [geometryEngine]
-  });
 
   jest.spyOn(mapViewUtils, "highlightFeatures").mockImplementation(jest.fn());
   jest.spyOn(publicNotificationUtils, "getSelectionIds").mockImplementation(jest.fn());

--- a/src/components/public-notification/test/public-notification.spec.tsx
+++ b/src/components/public-notification/test/public-notification.spec.tsx
@@ -18,7 +18,6 @@ import { h } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
 import { PublicNotification } from '../public-notification';
 import * as locale from "../../../utils/locale";
-import * as loadModules from "../../../utils/loadModules";
 import * as translations from "../../../assets/t9n/map-draw-tools/resources.json";
 import { geometryEngine, LayerView } from "../../../utils/test/mocks/jsApi";
 import * as queryUtils from "../../../utils/queryUtils";
@@ -36,10 +35,6 @@ beforeEach(() => {
   jest.spyOn(locale, "getLocaleComponentStrings").mockImplementation(() => [
     translations
   ] as any);
-
-  jest.spyOn(loadModules, "loadModules").mockImplementation(async () => {
-    return [geometryEngine]
-  });
 
   jest.spyOn(console, 'warn').mockImplementation(() => {});
 

--- a/src/components/refine-selection-tools/refine-selection-tools.tsx
+++ b/src/components/refine-selection-tools/refine-selection-tools.tsx
@@ -19,9 +19,10 @@ import { ERefineMode, ESelectionMode, ESelectionType, IRefineOperation } from ".
 import { getMapLayerView, highlightFeatures } from "../../utils/mapViewUtils";
 import { queryFeaturesByGeometry } from "../../utils/queryUtils";
 import state from "../../utils/publicNotificationStore";
-import { loadModules } from "../../utils/loadModules";
 import RefineSelectionTools_T9n from "../../assets/t9n/refine-selection-tools/resources.json";
 import { getLocaleComponentStrings } from "../../utils/locale";
+import GraphicsLayer from "@arcgis/core/layers/GraphicsLayer";
+import SketchViewModel from "@arcgis/core/widgets/Sketch/SketchViewModel";
 
 @Component({
   tag: "refine-selection-tools",
@@ -120,18 +121,6 @@ export class RefineSelectionTools {
   //  Properties (protected)
   //
   //--------------------------------------------------------------------------
-
-  /**
-   * esri/layers/GraphicsLayer: https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-GraphicsLayer.html
-   * The graphics layer constructor
-   */
-  protected GraphicsLayer: typeof __esri.GraphicsLayer;
-
-  /**
-   * esri/widgets/Sketch/SketchViewModel: https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Sketch-SketchViewModel.html
-   * The sketch view model constructor
-   */
-  protected SketchViewModel: typeof __esri.SketchViewModel;
 
   /**
    * {<layer title>: Graphic[]}: Collection of graphics returned from queries to the layer
@@ -240,7 +229,6 @@ export class RefineSelectionTools {
    */
   async componentWillLoad(): Promise<void> {
     await this._getTranslations();
-    await this._initModules();
   }
 
   /**
@@ -356,25 +344,6 @@ export class RefineSelectionTools {
   //--------------------------------------------------------------------------
 
   /**
-   * Load esri javascript api modules
-   *
-   * @returns Promise resolving when function is done
-   *
-   * @protected
-   */
-  protected async _initModules(): Promise<void> {
-    const [GraphicsLayer, SketchViewModel]: [
-      __esri.GraphicsLayerConstructor,
-      __esri.SketchViewModelConstructor
-    ] = await loadModules([
-      "esri/layers/GraphicsLayer",
-      "esri/widgets/Sketch/SketchViewModel"
-    ]);
-    this.GraphicsLayer = GraphicsLayer;
-    this.SketchViewModel = SketchViewModel;
-  }
-
-  /**
    * Initialize the graphics layer and skecth view model
    *
    * @returns Promise when the operation has completed
@@ -392,7 +361,7 @@ export class RefineSelectionTools {
    * @protected
    */
   protected _initSketchViewModel(): void {
-    this._sketchViewModel = new this.SketchViewModel({
+    this._sketchViewModel = new SketchViewModel({
       layer: this._sketchGraphicsLayer,
       defaultUpdateOptions: {
         tool: "reshape",
@@ -434,7 +403,7 @@ export class RefineSelectionTools {
     if (sketchIndex > -1) {
       this._sketchGraphicsLayer = this.mapView.map.layers.getItemAt(sketchIndex) as __esri.GraphicsLayer;
     } else {
-      this._sketchGraphicsLayer = new this.GraphicsLayer({ title });
+      this._sketchGraphicsLayer = new GraphicsLayer({ title });
       state.managedLayers.push(title);
       this.mapView.map.layers.add(this._sketchGraphicsLayer);
     }


### PR DESCRIPTION
@MikeTschudi thanks for questioning this the other day.

In the IA template they bring the map in with esm import. When testing on DevExt today I noticed that many things were failing with seemingly weird errors and I immediately wondered if mixing the two could cause issues. After testing with the map-card component (the only one that imports the map esm style within the component) a bit more I'm confident that is what's causing the errors...mixing amd and esm imported things doesn't work. 

This change breaks the other tests and demos that use the map and will need to think through how to handle for those but would like to get this in and publish to npm again to do further verification in IA. Will then go back and get the demos and tests updated.