### PR TITLE
remove deprecated constructors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcgis/core": "4.25.0-next.20221031",
         "@stencil/core": "^2.20.0",
         "focus-trap": "7.2.0",
         "minimist": "^1.2.6"
@@ -20,7 +19,7 @@
         "@stencil/postcss": "^2.1.0",
         "@stencil/sass": "^2.0.0",
         "@stencil/store": "^2.0.1",
-        "@types/arcgis-js-api": "^4.24.0",
+        "@types/arcgis-js-api": "^4.25.0-next.20221031",
         "@types/jest": "^27.0.3",
         "@types/node": "^16.11.11",
         "@types/puppeteer": "^5.4.2",
@@ -66,7 +65,8 @@
     "node_modules/@a11y/focus-trap": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@a11y/focus-trap/-/focus-trap-1.0.5.tgz",
-      "integrity": "sha512-3JOd6g+BALysWS8LNf0qdB8ltR651H/RCLAvUmfS0LIHwHO579XfjZUIZbURYiAZrcbp1CBAq4QZ2YwKNQZ1hw=="
+      "integrity": "sha512-3JOd6g+BALysWS8LNf0qdB8ltR651H/RCLAvUmfS0LIHwHO579XfjZUIZbURYiAZrcbp1CBAq4QZ2YwKNQZ1hw==",
+      "peer": true
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
@@ -79,28 +79,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@arcgis/core": {
-      "version": "4.25.0-next.20221031",
-      "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.25.0-next.20221031.tgz",
-      "integrity": "sha512-jq1p9xLBK4HoS87itECBswU2AoOslqInzmAMwz8FnBPdWuWNFpP1ZiCdDzS3W6GE9Rf/a4gO2kK0P/DmJMhoIQ==",
-      "dependencies": {
-        "@esri/arcgis-html-sanitizer": "~3.0.0",
-        "@esri/calcite-colors": "~6.0.1",
-        "@esri/calcite-components": "1.0.0-beta.97",
-        "@popperjs/core": "~2.11.6",
-        "focus-trap": "~7.0.0",
-        "luxon": "~3.0.4",
-        "sortablejs": "~1.15.0"
-      }
-    },
-    "node_modules/@arcgis/core/node_modules/focus-trap": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.0.0.tgz",
-      "integrity": "sha512-uT4Bl8TwU+5vVAx/DHil/1eVS54k9unqhK/vGy2KSh7esPmqgC0koAB9J2sJ+vtj8+vmiFyGk2unLkhNLQaxoA==",
-      "dependencies": {
-        "tabbable": "^6.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -763,14 +741,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@esri/arcgis-html-sanitizer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-3.0.1.tgz",
-      "integrity": "sha512-cwZJwsYCJZwtBQU2AmaiIVFg5nZcVwInPYja1/OgC9iKYO+ytZRoc5h+0S9/ygbFNoS8Nd0RX9A85stLX/BgiA==",
-      "dependencies": {
-        "xss": "1.0.13"
-      }
-    },
     "node_modules/@esri/arcgis-rest-auth": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.5.0.tgz",
@@ -876,15 +846,11 @@
       "deprecated": "Development work on ArcGIS REST JS 3.x has ceased. Types in this package have moved to their respective packages in 4.x.x https://developers.arcgis.com/arcgis-rest-js/release-notes/upgrade-v3-v4/.",
       "peer": true
     },
-    "node_modules/@esri/calcite-colors": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-colors/-/calcite-colors-6.0.1.tgz",
-      "integrity": "sha512-iGUIIpeMCJSTDGw4ZsxLwwxkml0QzOUJTtysjRryGbhSt183NEtwWKS+yQO19utXQz5LbQWjoav6x6CsawElkw=="
-    },
     "node_modules/@esri/calcite-components": {
       "version": "1.0.0-beta.97",
       "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.0.0-beta.97.tgz",
       "integrity": "sha512-pvuOQI01DCIr6kS+Jof/b5kLWRaDlYZStP8QUB5r4FYofHHST25iKlOS6525WD4S9xejthfb8S1PehTeMn5Wxg==",
+      "peer": true,
       "dependencies": {
         "@a11y/focus-trap": "1.0.5",
         "@floating-ui/dom": "1.0.3",
@@ -900,6 +866,7 @@
       "version": "2.18.1",
       "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.18.1.tgz",
       "integrity": "sha512-/fXkh1lwZ+X9JQCw50mPjhBogzEHOBvVC5pLoDLZqodVYK0DGWILM2YLV4dcIUBNEK8/HMDpO/Rq81/rS3mNOw==",
+      "peer": true,
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -1086,12 +1053,14 @@
     "node_modules/@floating-ui/core": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.1.0.tgz",
-      "integrity": "sha512-zbsLwtnHo84w1Kc8rScAo5GMk1GdecSlrflIbfnEBJwvTSj1SL6kkOYV+nHraMCPEy+RNZZUaZyL8JosDGCtGQ=="
+      "integrity": "sha512-zbsLwtnHo84w1Kc8rScAo5GMk1GdecSlrflIbfnEBJwvTSj1SL6kkOYV+nHraMCPEy+RNZZUaZyL8JosDGCtGQ==",
+      "peer": true
     },
     "node_modules/@floating-ui/dom": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.3.tgz",
       "integrity": "sha512-6H1kwjkOZKabApNtXRiYHvMmYJToJ1DV7rQ3xc/WJpOABhQIOJJOdz2AOejj8X+gcybaFmBpisVTZxBZAM3V0w==",
+      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.0.1"
       }
@@ -1687,15 +1656,6 @@
         "@octokit/openapi-types": "^12.11.0"
       }
     },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.6",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
-      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
-    },
     "node_modules/@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -1889,6 +1849,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/color/-/color-3.0.3.tgz",
       "integrity": "sha512-X//qzJ3d3Zj82J9sC/C18ZY5f43utPbAJ6PhYt/M7uG6etcF6MRpKdN880KBy43B0BMzSfeT96MzrsNjFI3GbA==",
+      "peer": true,
       "dependencies": {
         "@types/color-convert": "*"
       }
@@ -1897,6 +1858,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-2.0.0.tgz",
       "integrity": "sha512-m7GG7IKKGuJUXvkZ1qqG3ChccdIM/qBBo913z+Xft0nKCX4hAU/IxKwZBU4cpRZ7GS5kV4vOblUkILtSShCPXQ==",
+      "peer": true,
       "dependencies": {
         "@types/color-name": "*"
       }
@@ -1904,7 +1866,8 @@
     "node_modules/@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "peer": true
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.6",
@@ -3490,6 +3453,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
       "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1",
         "color-string": "^1.9.0"
@@ -3518,6 +3482,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
       "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "peer": true,
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -3547,7 +3512,8 @@
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
     },
     "node_modules/component-emitter": {
       "version": "1.3.0",
@@ -3682,7 +3648,8 @@
     "node_modules/cssfilter": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
-      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
+      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
+      "dev": true
     },
     "node_modules/cssom": {
       "version": "0.4.4",
@@ -8064,7 +8031,8 @@
     "node_modules/lodash-es": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "peer": true
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
@@ -8189,14 +8157,6 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/luxon": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.4.tgz",
-      "integrity": "sha512-aV48rGUwP/Vydn8HT+5cdr26YYQiUZ42NM6ToMoaGKwYfWbfLeRkEu1wXWMHBZT6+KyLfcbbtVcoQFCbbPjKlw==",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/make-dir": {
@@ -11019,6 +10979,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "peer": true,
       "dependencies": {
         "is-arrayish": "^0.3.1"
       }
@@ -11026,7 +10987,8 @@
     "node_modules/simple-swizzle/node_modules/is-arrayish": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "peer": true
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -11258,7 +11220,8 @@
     "node_modules/sortablejs": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.0.tgz",
-      "integrity": "sha512-bv9qgVMjUMf89wAvM6AxVvS/4MX3sPeN0+agqShejLU5z5GX4C75ow1O2e5k4L6XItUyAK3gH6AxSbXrOM5e8w=="
+      "integrity": "sha512-bv9qgVMjUMf89wAvM6AxVvS/4MX3sPeN0+agqShejLU5z5GX4C75ow1O2e5k4L6XItUyAK3gH6AxSbXrOM5e8w==",
+      "peer": true
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -12679,21 +12642,6 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
-    "node_modules/xss": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.13.tgz",
-      "integrity": "sha512-clu7dxTm1e8Mo5fz3n/oW3UCXBfV89xZ72jM8yzo1vR/pIS0w3sgB3XV2H8Vm6zfGnHL0FzvLJPJEBhd86/z4Q==",
-      "dependencies": {
-        "commander": "^2.20.3",
-        "cssfilter": "0.0.10"
-      },
-      "bin": {
-        "xss": "bin/xss"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -12790,7 +12738,8 @@
     "@a11y/focus-trap": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@a11y/focus-trap/-/focus-trap-1.0.5.tgz",
-      "integrity": "sha512-3JOd6g+BALysWS8LNf0qdB8ltR651H/RCLAvUmfS0LIHwHO579XfjZUIZbURYiAZrcbp1CBAq4QZ2YwKNQZ1hw=="
+      "integrity": "sha512-3JOd6g+BALysWS8LNf0qdB8ltR651H/RCLAvUmfS0LIHwHO579XfjZUIZbURYiAZrcbp1CBAq4QZ2YwKNQZ1hw==",
+      "peer": true
     },
     "@ampproject/remapping": {
       "version": "2.2.0",
@@ -12800,30 +12749,6 @@
       "requires": {
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
-      }
-    },
-    "@arcgis/core": {
-      "version": "4.25.0-next.20221031",
-      "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.25.0-next.20221031.tgz",
-      "integrity": "sha512-jq1p9xLBK4HoS87itECBswU2AoOslqInzmAMwz8FnBPdWuWNFpP1ZiCdDzS3W6GE9Rf/a4gO2kK0P/DmJMhoIQ==",
-      "requires": {
-        "@esri/arcgis-html-sanitizer": "~3.0.0",
-        "@esri/calcite-colors": "~6.0.1",
-        "@esri/calcite-components": "1.0.0-beta.97",
-        "@popperjs/core": "~2.11.6",
-        "focus-trap": "~7.0.0",
-        "luxon": "~3.0.4",
-        "sortablejs": "~1.15.0"
-      },
-      "dependencies": {
-        "focus-trap": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.0.0.tgz",
-          "integrity": "sha512-uT4Bl8TwU+5vVAx/DHil/1eVS54k9unqhK/vGy2KSh7esPmqgC0koAB9J2sJ+vtj8+vmiFyGk2unLkhNLQaxoA==",
-          "requires": {
-            "tabbable": "^6.0.0"
-          }
-        }
       }
     },
     "@babel/code-frame": {
@@ -13330,14 +13255,6 @@
         "strip-json-comments": "^3.1.1"
       }
     },
-    "@esri/arcgis-html-sanitizer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-3.0.1.tgz",
-      "integrity": "sha512-cwZJwsYCJZwtBQU2AmaiIVFg5nZcVwInPYja1/OgC9iKYO+ytZRoc5h+0S9/ygbFNoS8Nd0RX9A85stLX/BgiA==",
-      "requires": {
-        "xss": "1.0.13"
-      }
-    },
     "@esri/arcgis-rest-auth": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.5.0.tgz",
@@ -13433,15 +13350,11 @@
       "integrity": "sha512-FeX09YZsreTP/n1IQxxlFFyqOenCrn7sF8k/IX+l1hchSCMR0xWX6jYzy459qxUlFV/QWLTC1SsIJT7GWD8zTA==",
       "peer": true
     },
-    "@esri/calcite-colors": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-colors/-/calcite-colors-6.0.1.tgz",
-      "integrity": "sha512-iGUIIpeMCJSTDGw4ZsxLwwxkml0QzOUJTtysjRryGbhSt183NEtwWKS+yQO19utXQz5LbQWjoav6x6CsawElkw=="
-    },
     "@esri/calcite-components": {
       "version": "1.0.0-beta.97",
       "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.0.0-beta.97.tgz",
       "integrity": "sha512-pvuOQI01DCIr6kS+Jof/b5kLWRaDlYZStP8QUB5r4FYofHHST25iKlOS6525WD4S9xejthfb8S1PehTeMn5Wxg==",
+      "peer": true,
       "requires": {
         "@a11y/focus-trap": "1.0.5",
         "@floating-ui/dom": "1.0.3",
@@ -13456,7 +13369,8 @@
         "@stencil/core": {
           "version": "2.18.1",
           "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.18.1.tgz",
-          "integrity": "sha512-/fXkh1lwZ+X9JQCw50mPjhBogzEHOBvVC5pLoDLZqodVYK0DGWILM2YLV4dcIUBNEK8/HMDpO/Rq81/rS3mNOw=="
+          "integrity": "sha512-/fXkh1lwZ+X9JQCw50mPjhBogzEHOBvVC5pLoDLZqodVYK0DGWILM2YLV4dcIUBNEK8/HMDpO/Rq81/rS3mNOw==",
+          "peer": true
         }
       }
     },
@@ -13596,12 +13510,14 @@
     "@floating-ui/core": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.1.0.tgz",
-      "integrity": "sha512-zbsLwtnHo84w1Kc8rScAo5GMk1GdecSlrflIbfnEBJwvTSj1SL6kkOYV+nHraMCPEy+RNZZUaZyL8JosDGCtGQ=="
+      "integrity": "sha512-zbsLwtnHo84w1Kc8rScAo5GMk1GdecSlrflIbfnEBJwvTSj1SL6kkOYV+nHraMCPEy+RNZZUaZyL8JosDGCtGQ==",
+      "peer": true
     },
     "@floating-ui/dom": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.3.tgz",
       "integrity": "sha512-6H1kwjkOZKabApNtXRiYHvMmYJToJ1DV7rQ3xc/WJpOABhQIOJJOdz2AOejj8X+gcybaFmBpisVTZxBZAM3V0w==",
+      "peer": true,
       "requires": {
         "@floating-ui/core": "^1.0.1"
       }
@@ -14101,11 +14017,6 @@
         "@octokit/openapi-types": "^12.11.0"
       }
     },
-    "@popperjs/core": {
-      "version": "2.11.6",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
-      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
-    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -14268,6 +14179,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/color/-/color-3.0.3.tgz",
       "integrity": "sha512-X//qzJ3d3Zj82J9sC/C18ZY5f43utPbAJ6PhYt/M7uG6etcF6MRpKdN880KBy43B0BMzSfeT96MzrsNjFI3GbA==",
+      "peer": true,
       "requires": {
         "@types/color-convert": "*"
       }
@@ -14276,6 +14188,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-2.0.0.tgz",
       "integrity": "sha512-m7GG7IKKGuJUXvkZ1qqG3ChccdIM/qBBo913z+Xft0nKCX4hAU/IxKwZBU4cpRZ7GS5kV4vOblUkILtSShCPXQ==",
+      "peer": true,
       "requires": {
         "@types/color-name": "*"
       }
@@ -14283,7 +14196,8 @@
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "peer": true
     },
     "@types/graceful-fs": {
       "version": "4.1.6",
@@ -15439,6 +15353,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
       "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "peer": true,
       "requires": {
         "color-convert": "^2.0.1",
         "color-string": "^1.9.0"
@@ -15461,6 +15376,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
       "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "peer": true,
       "requires": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -15484,7 +15400,8 @@
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
     },
     "component-emitter": {
       "version": "1.3.0",
@@ -15596,7 +15513,8 @@
     "cssfilter": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
-      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
+      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
+      "dev": true
     },
     "cssom": {
       "version": "0.4.4",
@@ -18954,7 +18872,8 @@
     "lodash-es": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "peer": true
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
@@ -19058,11 +18977,6 @@
       "requires": {
         "yallist": "^3.0.2"
       }
-    },
-    "luxon": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.4.tgz",
-      "integrity": "sha512-aV48rGUwP/Vydn8HT+5cdr26YYQiUZ42NM6ToMoaGKwYfWbfLeRkEu1wXWMHBZT6+KyLfcbbtVcoQFCbbPjKlw=="
     },
     "make-dir": {
       "version": "3.1.0",
@@ -21182,6 +21096,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "peer": true,
       "requires": {
         "is-arrayish": "^0.3.1"
       },
@@ -21189,7 +21104,8 @@
         "is-arrayish": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+          "peer": true
         }
       }
     },
@@ -21379,7 +21295,8 @@
     "sortablejs": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.0.tgz",
-      "integrity": "sha512-bv9qgVMjUMf89wAvM6AxVvS/4MX3sPeN0+agqShejLU5z5GX4C75ow1O2e5k4L6XItUyAK3gH6AxSbXrOM5e8w=="
+      "integrity": "sha512-bv9qgVMjUMf89wAvM6AxVvS/4MX3sPeN0+agqShejLU5z5GX4C75ow1O2e5k4L6XItUyAK3gH6AxSbXrOM5e8w==",
+      "peer": true
     },
     "source-map": {
       "version": "0.6.1",
@@ -22494,15 +22411,6 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
-    },
-    "xss": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.13.tgz",
-      "integrity": "sha512-clu7dxTm1e8Mo5fz3n/oW3UCXBfV89xZ72jM8yzo1vR/pIS0w3sgB3XV2H8Vm6zfGnHL0FzvLJPJEBhd86/z4Q==",
-      "requires": {
-        "commander": "^2.20.3",
-        "cssfilter": "0.0.10"
-      }
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@stencil/postcss": "^2.1.0",
     "@stencil/sass": "^2.0.0",
     "@stencil/store": "^2.0.1",
-    "@types/arcgis-js-api": "^4.24.0",
+    "@types/arcgis-js-api": "^4.25.0-next.20221031",
     "@types/jest": "^27.0.3",
     "@types/node": "^16.11.11",
     "@types/puppeteer": "^5.4.2",
@@ -66,7 +66,6 @@
     "@esri/solution-common": "1.5.3"
   },
   "dependencies": {
-    "@arcgis/core": "4.25.0-next.20221031",
     "minimist": "^1.2.6",
     "@stencil/core": "^2.20.0",
     "focus-trap": "7.2.0"

--- a/src/components/map-card/map-card.tsx
+++ b/src/components/map-card/map-card.tsx
@@ -89,12 +89,12 @@ export class MapCard {
   /**
    * esri/views/MapView: https://developers.arcgis.com/javascript/latest/api-reference/esri-views-MapView.html
    */
-  protected MapView: typeof __esri.MapView;
+  protected MapView: typeof import("esri/views/MapView");
 
   /**
    * esri/WebMap: https://developers.arcgis.com/javascript/latest/api-reference/esri-WebMap.html
    */
-  protected WebMap: typeof __esri.WebMap;
+  protected WebMap: typeof import("esri/WebMap");
 
   /**
    * string: the id of map currently displayed
@@ -198,10 +198,7 @@ export class MapCard {
    * @protected
    */
   protected async _initModules(): Promise<void> {
-    const [WebMap, MapView]: [
-      __esri.WebMapConstructor,
-      __esri.MapViewConstructor
-    ] = await loadModules([
+    const [WebMap, MapView] = await loadModules([
       "esri/WebMap",
       "esri/views/MapView"
     ]);

--- a/src/components/map-draw-tools/map-draw-tools.tsx
+++ b/src/components/map-draw-tools/map-draw-tools.tsx
@@ -95,12 +95,12 @@ export class MapDrawTools {
   /**
    * esri/layers/GraphicsLayer: https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-GraphicsLayer.html?#constructors-summary
    */
-  protected GraphicsLayer: typeof __esri.GraphicsLayer;
+  protected GraphicsLayer: typeof import("esri/layers/GraphicsLayer");
 
   /**
    * esri/widgets/Sketch: https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Sketch.html#constructors-summary
    */
-  protected Sketch: typeof __esri.Sketch;
+  protected Sketch: typeof import("esri/widgets/Sketch");
 
   /**
    * The container element for the sketch widget
@@ -227,10 +227,7 @@ export class MapDrawTools {
    * @protected
    */
   protected async _initModules(): Promise<void> {
-    const [GraphicsLayer, Sketch]: [
-      __esri.GraphicsLayerConstructor,
-      __esri.SketchConstructor
-    ] = await loadModules([
+    const [GraphicsLayer, Sketch] = await loadModules([
       "esri/layers/GraphicsLayer",
       "esri/widgets/Sketch"
     ]);

--- a/src/components/map-search/map-search.tsx
+++ b/src/components/map-search/map-search.tsx
@@ -71,7 +71,7 @@ export class MapSearch {
   /**
    * esri/widgets/Search: https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Search.html
    */
-  protected Search: typeof __esri.widgetsSearch
+  protected Search: typeof import("esri/widgets/Search");
 
   /**
    * HTMLElement: The container div for the search widget
@@ -170,9 +170,7 @@ export class MapSearch {
    * @protected
    */
   protected async _initModules(): Promise<void> {
-    const [Search]: [
-      __esri.widgetsSearchConstructor
-    ] = await loadModules([
+    const [Search] = await loadModules([
       "esri/widgets/Search"
     ]);
     this.Search = Search;

--- a/src/components/map-select-tools/map-select-tools.tsx
+++ b/src/components/map-select-tools/map-select-tools.tsx
@@ -104,24 +104,19 @@ export class MapSelectTools {
   //--------------------------------------------------------------------------
 
   /**
-   * esri/geometry/Geometry: https://developers.arcgis.com/javascript/latest/api-reference/esri-geometry-Geometry.html
-   */
-  protected Geometry: typeof __esri.Geometry;
-
-  /**
    * esri/Graphic: https://developers.arcgis.com/javascript/latest/api-reference/esri-Graphic.html
    */
-  protected Graphic: typeof __esri.Graphic;
+  protected Graphic: typeof import("esri/Graphic");
 
   /**
    * esri/layers/GraphicsLayer: https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-GraphicsLayer.html
    */
-  protected GraphicsLayer: typeof __esri.GraphicsLayer;
+  protected GraphicsLayer: typeof import("esri/layers/GraphicsLayer");
 
   /**
    * esri/widgets/Search: https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Search.html
    */
-  protected Search: typeof __esri.widgetsSearch;
+  protected Search: typeof import("esri/widgets/Search");
 
   /**
    * esri/geometry/geometryEngine: https://developers.arcgis.com/javascript/latest/api-reference/esri-geometry-geometryEngine.html
@@ -448,23 +443,15 @@ export class MapSelectTools {
    * @protected
    */
   protected async _initModules(): Promise<void> {
-    const [GraphicsLayer, Graphic, Search, Geometry, geometryEngine]: [
-      __esri.GraphicsLayerConstructor,
-      __esri.GraphicConstructor,
-      __esri.widgetsSearchConstructor,
-      __esri.GeometryConstructor,
-      __esri.geometryEngine
-    ] = await loadModules([
+    const [GraphicsLayer, Graphic, Search, geometryEngine] = await loadModules([
       "esri/layers/GraphicsLayer",
       "esri/Graphic",
       "esri/widgets/Search",
-      "esri/geometry/Geometry",
       "esri/geometry/geometryEngine"
     ]);
     this.GraphicsLayer = GraphicsLayer;
     this.Graphic = Graphic;
     this.Search = Search;
-    this.Geometry = Geometry;
     this._geometryEngine = geometryEngine;
   }
 

--- a/src/components/refine-selection-tools/refine-selection-tools.tsx
+++ b/src/components/refine-selection-tools/refine-selection-tools.tsx
@@ -125,13 +125,13 @@ export class RefineSelectionTools {
    * esri/layers/GraphicsLayer: https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-GraphicsLayer.html
    * The graphics layer constructor
    */
-  protected GraphicsLayer: typeof __esri.GraphicsLayer;
+  protected GraphicsLayer: typeof import("esri/layers/GraphicsLayer");
 
   /**
    * esri/widgets/Sketch/SketchViewModel: https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Sketch-SketchViewModel.html
    * The sketch view model constructor
    */
-  protected SketchViewModel: typeof __esri.SketchViewModel;
+  protected SketchViewModel: typeof import("esri/widgets/Sketch/SketchViewModel");
 
   /**
    * {<layer title>: Graphic[]}: Collection of graphics returned from queries to the layer
@@ -374,10 +374,7 @@ export class RefineSelectionTools {
    * @protected
    */
   protected async _initModules(): Promise<void> {
-    const [GraphicsLayer, SketchViewModel]: [
-      __esri.GraphicsLayerConstructor,
-      __esri.SketchViewModelConstructor
-    ] = await loadModules([
+    const [GraphicsLayer, SketchViewModel] = await loadModules([
       "esri/layers/GraphicsLayer",
       "esri/widgets/Sketch/SketchViewModel"
     ]);


### PR DESCRIPTION
@MikeTschudi seeing a failure when trying to create instances of things like GraphicsLayer in devext that I don't see when testing locally in the Instant App. Hoping that its related to the use of these Constructors that are now deprecated. 