### PR TITLE
Keep Stencil from mangling RTL text

### DIFF
--- a/src/components/pdf-download/pdf-download.tsx
+++ b/src/components/pdf-download/pdf-download.tsx
@@ -164,11 +164,14 @@ export class PdfDownload {
           disabled={this.disabled}
           label=""
           ref={(el) => { this._labelInfoElement = el }}
-        >
-          {this._renderItems()}
-        </calcite-select>
+        />
       </Host>
     );
+  }
+
+  componentDidRender(): void {
+    // Render the options outside of Stencil's rendering so that it doesn't mangle RTL text with embedded LTR
+    this._renderOptions();
   }
 
   //--------------------------------------------------------------------------
@@ -203,7 +206,9 @@ export class PdfDownload {
     labelInfo: any
   ): string {
     const lNum = labelInfo.descriptionPDF.labelsPerPageDisplay;
-    const lSize = `${labelInfo.descriptionPDF.labelWidthDisplay} x ${labelInfo.descriptionPDF.labelHeightDisplay}`;
+    const lSize =
+      "&lrm;" + (labelInfo.descriptionPDF.labelWidthDisplay as string) + " x " +
+      (labelInfo.descriptionPDF.labelHeightDisplay as string) + "&rlm;";
     return this._translations.pdfLabel.replace("{{n}}", lNum).replace("{{labelSize}}", lSize);
   }
 
@@ -218,21 +223,22 @@ export class PdfDownload {
   }
 
   /**
-   * Renders the pdf export size options
-   *
-   * @returns Node array of size options
+   * Renders the pdf export size options and adds them to the `select` component
    *
    * @protected
    */
-  protected _renderItems(): VNode[] {
+  protected _renderOptions(): void {
     const s: any = pdfLabelFormats;
     const sortedPdfIndo = (s.default || s).sort((a, b) => {
       const _a = parseInt(a.descriptionPDF.labelsPerPageDisplay, 10);
       const _b = parseInt(b.descriptionPDF.labelsPerPageDisplay, 10);
       return _a < _b ? -1 : _a > _b ? 1 : 0
     });
-    return sortedPdfIndo.map((l) => {
-      return (<calcite-option value={l}>{this._getLabelSizeText(l)}</calcite-option>)
+    sortedPdfIndo.forEach((l) => {
+      const option = document.createElement("calcite-option");
+      option.value = l;
+      option.innerHTML = this._getLabelSizeText(l);
+      this._labelInfoElement.appendChild(option);
     });
   }
 


### PR DESCRIPTION
Render the label-size options outside of JSX rendering so that it doesn't mangle RTL text with embedded LTR.

The problem:
![image](https://github.com/Esri/solutions-components/assets/2125181/484d4d49-29a3-4e00-9bd9-0634d3780ad6)
is rendering as
![image](https://github.com/Esri/solutions-components/assets/2125181/7ec74eb5-fc61-4bf0-89a0-649041e172d5)

The option entries are created by substituting into a language-dependent string such as `"{{n}} בדף | {{labelSize}}"`. `labelSize` is a concatenation of two properties from the labelFormats.json file:  `labelWidthDisplay` + " x " + `labelHeightDisplay`. This works in a regular webpage, but StencilJS appears to mangle the string when the options are run through JSX. Mangling occurs even when the language-dependent string is changed to  `"{{n}} בדף | {{labelSize1}} x {{labelSize2}}"`.

With this PR, the options are added to the `calcite-select` component via regular JavaScript rather than via JSX and the value that replaces `labelSize` is bracketed by the directional tags `&lrm;` and `&rlm;`. This fixes the embedded directionality in RTL strings and has no effect in LTR strings.