### PR TITLE
ensure value is number

### DIFF
--- a/src/components/public-notification/public-notification.tsx
+++ b/src/components/public-notification/public-notification.tsx
@@ -1045,7 +1045,7 @@ export class PublicNotification {
         </div>
         <div class="padding-sides-1">
           <pdf-download
-            defaultNumLabelsPerPage={this.defaultNumLabelsPerPage}
+            defaultNumLabelsPerPage={parseInt(this.defaultNumLabelsPerPage.toString(), 10)}
             disabled={!this._downloadActive}
             ref={(el) => { this._downloadTools = el }}
           />


### PR DESCRIPTION
IA issue with default num per page for pdf export not being honored