### PR TITLE
Provide shortcut exit if there are no related records in PN

### DIFF
--- a/src/utils/downloadUtils.ts
+++ b/src/utils/downloadUtils.ts
@@ -815,6 +815,11 @@ export async function _prepareLabels(
       }
     );
 
+    // Handle the special case where no related records were found for the set of features
+    if (relatedFeatureIds.length === 0) {
+      return Promise.resolve([]);
+    }
+
     // Remove duplicates
     relatedFeatureIds.sort();
     relatedFeatureIds = relatedFeatureIds.filter((id, i) => i === 0 ? true : id !== relatedFeatureIds[i-1]);


### PR DESCRIPTION
#405 

For now, features without related records have no output. This means that in the example provided in this issue, a blank page is produced. For the next release, we propose providing feedback on the Export page of Public Notification that tells how many labels will be exported, and disabling the Export button if there are no labels.