### PR TITLE
Use POST instead of GET for querying related records

### DIFF
--- a/src/utils/downloadUtils.ts
+++ b/src/utils/downloadUtils.ts
@@ -539,12 +539,8 @@ export function _getFeatureServiceRelatedRecordsTranche(
 
       // If exceededTransferLimit is true, then there are more records to retrieve and the feature service
       // supports the resultOffset parameter
-      if (response.exceededTransferLimit) {
-        return _getFeatureServiceRelatedRecordsTranche(
-          options, relationships, resultOffset + response.relatedRecordGroups.length);
-      } else {
-        return Promise.resolve(relationships);
-      }
+      return response.exceededTransferLimit ? _getFeatureServiceRelatedRecordsTranche(
+          options, relationships, resultOffset + response.relatedRecordGroups.length) : Promise.resolve(relationships);
     }
   );
 }

--- a/src/utils/test/downloadUtils.spec.tsx
+++ b/src/utils/test/downloadUtils.spec.tsx
@@ -267,7 +267,13 @@ describe("downloadUtils", () => {
     it("handles a feature layer", () => {
       const url = "https://servicesdev.arcgis.com/D2C14713795/ArcGIS/rest/services/addresses/FeatureServer/0";
       const layerId = 5;
-      const expectedOptions: restFeatureLayer.IQueryRelatedOptions = {
+      const expectedOptions: downloadUtils.IQueryRelatedOptionsOffset = {
+        httpMethod: "POST",
+        objectIds: undefined,
+        relationshipId: undefined,
+        params: {
+          resultOffset: 0
+        },
         url
       };
       const queryResponse: restFeatureLayer.IQueryRelatedResponse = { relatedRecordGroups: [] };
@@ -280,7 +286,13 @@ describe("downloadUtils", () => {
     it("handles a feature service", () => {
       const url = "https://servicesdev.arcgis.com/D2C14713795/ArcGIS/rest/services/addresses/FeatureServer";
       const layerId = 5;
-      const expectedOptions: restFeatureLayer.IQueryRelatedOptions = {
+      const expectedOptions: downloadUtils.IQueryRelatedOptionsOffset = {
+        httpMethod: "POST",
+        objectIds: undefined,
+        relationshipId: undefined,
+        params: {
+          resultOffset: 0
+        },
         url: "https://servicesdev.arcgis.com/D2C14713795/ArcGIS/rest/services/addresses/FeatureServer/5"
       };
       const queryResponse: restFeatureLayer.IQueryRelatedResponse = { relatedRecordGroups: [] };
@@ -295,10 +307,14 @@ describe("downloadUtils", () => {
       const layerId = 5;
       const relationshipId = 3;
       const objectIds = [7, 8, 9];
-      const expectedOptions: restFeatureLayer.IQueryRelatedOptions = {
-        url,
+      const expectedOptions: downloadUtils.IQueryRelatedOptionsOffset = {
+        httpMethod: "POST",
+        objectIds,
         relationshipId,
-        objectIds
+        params: {
+          resultOffset: 0
+        },
+        url
       };
       const queryResponse: restFeatureLayer.IQueryRelatedResponse = { relatedRecordGroups: [] };
       const queryRelatedSpy = jest.spyOn(restFeatureLayer, "queryRelated").mockResolvedValue(queryResponse);


### PR DESCRIPTION
to avoid limits on GET URL length.

And, if the feature layer supports the "supportsQueryRelatedPagination" capability, continue fetch until all results are returned.

#404