### PR TITLE
Update demos

### DIFF
--- a/src/assets/styles/styles.scss
+++ b/src/assets/styles/styles.scss
@@ -19,7 +19,6 @@
 html, body {
   @apply w-full
     h-full
-    flex
     overflow-y-hidden;
   background-color: $solutions-background-color;
   margin: 0px;

--- a/src/components/solution-item-sharing/solution-item-sharing.tsx
+++ b/src/components/solution-item-sharing/solution-item-sharing.tsx
@@ -163,7 +163,7 @@ export class SolutionItemSharing {
     this.sharing = this.sharing.map((itemShare: IItemShare) => {
       if (itemShare.id === id) {
         // update the item
-        itemShare.shareItem = event.detail.switched;
+        itemShare.shareItem = event.target.checked;
 
         // update the item in the store
         const itemEdit: IItemTemplateEdit = state.getItemInfo(id);

--- a/src/components/solution-spatial-ref/solution-spatial-ref.tsx
+++ b/src/components/solution-spatial-ref/solution-spatial-ref.tsx
@@ -169,12 +169,12 @@ export class SolutionSpatialRef {
    * Toggles the ability to set the default spatial reference.
    */
   protected _updateLocked(event: any): void {
-    this.locked = !event.detail.switched;
+    this.locked = !event.target.checked;
     this._updateStore();
     if (!this.loaded) {
       // when this is switched on when loading we have reloaded a solution that
       // has a custom wkid param and we should honor the settings they already have in the templates
-      if (event.detail.switched) {
+      if (event.target.checked) {
         // By default enable all Feature Services on first load
         this._setFeatureServiceDefaults(this.services);
       }
@@ -241,12 +241,12 @@ export class SolutionSpatialRef {
    */
   protected _updateEnabledServices(event: any, name: string): void {
     const spatialReferenceInfo = state.getStoreInfo("spatialReferenceInfo");
-    spatialReferenceInfo.services[name] = event.detail.switched;
+    spatialReferenceInfo.services[name] = event.target.checked;
     state.setStoreInfo("spatialReferenceInfo", spatialReferenceInfo);
 
     this.featureServiceSpatialReferenceChange.emit({
       name,
-      enabled: event.detail.switched
+      enabled: event.target.checked
     });
   }
 


### PR DESCRIPTION
1. Changed event variable to match calcite changes
2. Removed "flex" property from `html` & `body` tags to change demo app displays from
![image](https://github.com/Esri/solutions-components/assets/2125181/5977c985-5bfc-4f03-9d38-178b55cc5d5a)
to
![image](https://github.com/Esri/solutions-components/assets/2125181/1fe31b59-8b85-46ea-abe3-0511c1a4d753)
