### PR TITLE
Fix values sent via spatialReferenceChange event

### DIFF
--- a/src/components/solution-spatial-ref/test/solution-spatial-ref.e2e.ts
+++ b/src/components/solution-spatial-ref/test/solution-spatial-ref.e2e.ts
@@ -41,9 +41,6 @@ describe('solution-spatial-ref', () => {
     await page.waitForChanges();
     await spatial_ref.setProperty('value', newSpatialRef);
     await page.waitForChanges();
-    /*
-    expect(await spatial_ref.getProperty('value')).toBe(newSpatialRef);
-    */
 
     const solution_spatial_ref = await page.find('solution-spatial-ref');
     expect(await solution_spatial_ref.getProperty('value')).toBe(newSpatialRef);

--- a/src/components/spatial-ref/spatial-ref.tsx
+++ b/src/components/spatial-ref/spatial-ref.tsx
@@ -61,10 +61,6 @@ export class SpatialRef {
 
   @Watch("value")
   valueChanged(newValue: string): void {
-    this.spatialReferenceChange.emit({
-      oldValue: this.value,
-      newValue: newValue
-    });
     this._spatialRef = this._createSpatialRefDisplay(newValue);
     const searchBox = document.getElementById("calcite-sr-search") as HTMLCalciteInputElement;
     if (searchBox) {
@@ -233,6 +229,10 @@ export class SpatialRef {
    */
   protected _setSpatialRef(wkid: string): void {
     if (this.value !== wkid) {
+      this.spatialReferenceChange.emit({
+        oldValue: this.value,
+        newValue: wkid
+      });
       this.value = wkid;
     }
   }

--- a/src/components/spatial-ref/spatial-ref.tsx
+++ b/src/components/spatial-ref/spatial-ref.tsx
@@ -67,6 +67,14 @@ export class SpatialRef {
       searchBox.value = this._srSearchText = "";
     }
     this._clearSelection();
+
+    if (this._cachedValue !== this.value) {
+      this.spatialReferenceChange.emit({
+        oldValue: this._cachedValue,
+        newValue: this.value
+      });
+      this._cachedValue = this.value;
+    }
   }
 
   //--------------------------------------------------------------------------
@@ -112,6 +120,11 @@ export class SpatialRef {
   //  Properties (protected)
   //
   //--------------------------------------------------------------------------
+
+  /**
+   * Holds a pre-change value of the wkid so that an event can be posted with the cached and new values.
+   */
+  @State() protected _cachedValue = this.defaultWkid.toString();
 
   /**
    * Internal representation of component's value for display purposes.
@@ -229,10 +242,6 @@ export class SpatialRef {
    */
   protected _setSpatialRef(wkid: string): void {
     if (this.value !== wkid) {
-      this.spatialReferenceChange.emit({
-        oldValue: this.value,
-        newValue: wkid
-      });
       this.value = wkid;
     }
   }


### PR DESCRIPTION
Previously, `oldValue` and `newValue` both contained the new value.