### PR TITLE
Handle newline inserted via Arcade expression

### DIFF
--- a/src/utils/downloadUtils.ts
+++ b/src/utils/downloadUtils.ts
@@ -1051,7 +1051,7 @@ export async function _prepareLabelsFromPattern(
         const match: string = arcadeExpressionMatches[i];
         const expressionName = match.substring(match.indexOf("/") + 1, match.length - 1);
         const value = await arcadeExecutors[expressionName].executeAsync({"$feature": feature, "$layer": layer});
-        labelPrep = labelPrep.replace(match, value);
+        labelPrep = labelPrep.replace(match, value).replace(/\n/gi, "|");
       }
 
       // Replace non-Arcade fields in this feature


### PR DESCRIPTION
The expression: `"Line 1 test" + TextFormatting.NewLine + "Line 2 test"` was creating the pattern `"Line 1 test\nLine 2 test"`, which was "cleaned up" at the very end of label generation into `"Line 1 test|Line 2 test"`.

What needs to be done is to convert the `\n` into `|` right after the Arcade processing, after which it will be handled like other newlines in the label's pattern. Newlines are symbolized by `|` in label patterns to simplify processing to remove blank lines since `\n` is a rather special symbol. 