### PR TITLE
Fixed the handling of column names

### DIFF
--- a/src/utils/test/downloadUtils.spec.tsx
+++ b/src/utils/test/downloadUtils.spec.tsx
@@ -251,10 +251,49 @@ describe("downloadUtils", () => {
 
   });
 
+  describe("_extractHeaderNames", () => {
+
+    it("handles a single-line label", () => {
+      const labelSpec = "{PSTLCITY}, {PSTLSTATE} {PSTLZIP5}";
+      const headerNames = downloadUtils._extractHeaderNames(labelSpec);
+      const expectedHeaderNames = ["PSTLCITY__PSTLSTATE__PSTLZIP5"];
+      expect(headerNames).toEqual(expectedHeaderNames);
+    });
+
+    it("handles a multi-line label", () => {
+      const labelSpec = "{OWNERNM1}|{PSTLADDRESS}|{PSTLCITY}, {PSTLSTATE} {PSTLZIP5}";
+      const headerNames = downloadUtils._extractHeaderNames(labelSpec);
+      const expectedHeaderNames = ["OWNERNM1", "PSTLADDRESS", "PSTLCITY__PSTLSTATE__PSTLZIP5"];
+      expect(headerNames).toEqual(expectedHeaderNames);
+    });
+
+    it("handles a multi-line label with a line without attributes", () => {
+      const labelSpec = "{OWNERNM1}|Line without attributes|{PSTLCITY}, {PSTLSTATE} {PSTLZIP5}";
+      const headerNames = downloadUtils._extractHeaderNames(labelSpec);
+      const expectedHeaderNames = ["OWNERNM1", "column_2", "PSTLCITY__PSTLSTATE__PSTLZIP5"];
+      expect(headerNames).toEqual(expectedHeaderNames);
+    });
+
+    it("handles a label with an Arcade expression", () => {
+      const labelSpec = "{expression/expr0}|{OWNERNM1}|{PSTLADDRESS}|{PSTLCITY}, {PSTLSTATE} {PSTLZIP5}";
+      const headerNames = downloadUtils._extractHeaderNames(labelSpec);
+      const expectedHeaderNames = ["expr0", "OWNERNM1", "PSTLADDRESS", "PSTLCITY__PSTLSTATE__PSTLZIP5"];
+      expect(headerNames).toEqual(expectedHeaderNames);
+    });
+
+    it("handles a label with multiple Arcade expressions", () => {
+      const labelSpec = "{expression/expr3}: {expression/expr1}|{OWNERNM1}|{expression/expr0}|{PSTLCITY}, {PSTLSTATE} {PSTLZIP5}";
+      const headerNames = downloadUtils._extractHeaderNames(labelSpec);
+      const expectedHeaderNames = ["expr3__expr1", "OWNERNM1", "expr0", "PSTLCITY__PSTLSTATE__PSTLZIP5"];
+      expect(headerNames).toEqual(expectedHeaderNames);
+    });
+
+  });
+
   describe("_getExpressionsFromLabel", () => {
 
     it("handles a label with ASCII expression names", () => {
-      const labelSpec = "{expression/expr0}\n{OWNERNM1}\n{PSTLADDRESS}\n{PSTLCITY}, {PSTLSTATE} {PSTLZIP5}";
+      const labelSpec = "{expression/expr0}|{OWNERNM1}|{PSTLADDRESS}|{PSTLCITY}, {PSTLSTATE} {PSTLZIP5}";
       const expectedExpressions = ["{expression/expr0}"];
       const expressions = downloadUtils._getExpressionsFromLabel(labelSpec);
       expect(expressions).toEqual(expectedExpressions);


### PR DESCRIPTION
When a popup has more than one attribute on a line, the export to CSV contains one column heading per attribute, but that doesn't match the content in the columns.

For example, the single-line format 
` {expression/expr0} {STATUS} {RES_TYPE} {NATIONALGR} `
produces

STATUS | RES_TYPE | NATIONALGR
-- | -- | --
708 EAST CAPITOL STREET NE ACTIVE   RESIDENTIAL 18S UJ 26917 06474 |   |  
716 EAST CAPITOL STREET NE ACTIVE   RESIDENTIAL 18S UJ 26944 06473 |   |  
