### PR TITLE
Replaced arcgis-js-api package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.8.67",
       "license": "Apache-2.0",
       "dependencies": {
+        "@arcgis/core": "^4.30.8",
         "@esri/arcgis-rest-auth": "^3.7.0",
         "@esri/arcgis-rest-feature-layer": "^3.7.0",
         "@esri/arcgis-rest-portal": "^3.7.0",
@@ -47,7 +48,6 @@
         "@types/node": "^20.14.10",
         "@typescript-eslint/eslint-plugin": "^7.13.1",
         "@typescript-eslint/parser": "^7.16.0",
-        "arcgis-js-api": "~4.29.10",
         "autoprefixer": "^10.4.19",
         "babel-jest": "^29.7.0",
         "braces": "^3.0.3",
@@ -274,6 +274,97 @@
       "resolved": "https://registry.npmjs.org/@analytics/type-utils/-/type-utils-0.3.1.tgz",
       "integrity": "sha512-9Ej6c9ulj5DNE29eFk3s49/1b89M8mbQ7BoJEQAQg/k86HOVrAEWQUScr359WVSOyGNBsSYE1qILC3XFTTtgtw==",
       "dev": true
+    },
+    "node_modules/@arcgis/core": {
+      "version": "4.30.8",
+      "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.30.8.tgz",
+      "integrity": "sha512-nb1PwcPcqIKwSBb0wGF3DAHnA+G/2xcgXoZCVZQo4pvQSBTJQNvuXDxFhTCugsAAPh96FiQ4FL6ibEFO/jM9lA==",
+      "dependencies": {
+        "@esri/arcgis-html-sanitizer": "~4.0.3",
+        "@esri/calcite-colors": "~6.1.0",
+        "@esri/calcite-components": "^2.8.5",
+        "@vaadin/grid": "~24.3.13",
+        "@zip.js/zip.js": "~2.7.44",
+        "luxon": "~3.4.4",
+        "marked": "~12.0.2",
+        "sortablejs": "~1.15.2"
+      }
+    },
+    "node_modules/@arcgis/core/node_modules/@esri/arcgis-html-sanitizer": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-4.0.3.tgz",
+      "integrity": "sha512-B06V4Spjhcy2zcKH9SaTrZwRGjUTlsCSGImdCpe7fN/Q3HxLa4QosMgrRJQ+Q8guLhBA177+6Fjwzl/xIrmY7A==",
+      "dependencies": {
+        "xss": "1.0.13"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@arcgis/core/node_modules/@esri/calcite-components": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-2.10.1.tgz",
+      "integrity": "sha512-8M2ZBYcEk20x34TDxZ6H5rLCWtGrOJLtHA/k6yWL/GJTC85/gvY153XxbGN8F1ywJb/3imvhy/SlfNRPnVPQNQ==",
+      "dependencies": {
+        "@floating-ui/dom": "1.6.5",
+        "@stencil/core": "4.18.3",
+        "@types/color": "3.0.6",
+        "color": "4.2.3",
+        "composed-offset-position": "0.0.4",
+        "dayjs": "1.11.11",
+        "focus-trap": "7.5.4",
+        "lodash-es": "4.17.21",
+        "sortablejs": "1.15.1",
+        "timezone-groups": "0.8.0",
+        "type-fest": "4.18.2"
+      }
+    },
+    "node_modules/@arcgis/core/node_modules/@esri/calcite-components/node_modules/sortablejs": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.1.tgz",
+      "integrity": "sha512-P5Cjvb0UG1ZVNiDPj/n4V+DinttXG6K8n7vM/HQf0C25K3YKQTQY6fsr/sEGsJGpQ9exmPxluHxKBc0mLKU1lQ=="
+    },
+    "node_modules/@arcgis/core/node_modules/@floating-ui/dom": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.5.tgz",
+      "integrity": "sha512-Nsdud2X65Dz+1RHjAIP0t8z5e2ff/IRbei6BqFrl1urT8sDVzM1HMQ+R0XcU5ceRfyO3I6ayeqIfh+6Wb8LGTw==",
+      "dependencies": {
+        "@floating-ui/core": "^1.0.0",
+        "@floating-ui/utils": "^0.2.0"
+      }
+    },
+    "node_modules/@arcgis/core/node_modules/@stencil/core": {
+      "version": "4.18.3",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.18.3.tgz",
+      "integrity": "sha512-8yoG5AFQYEPocVtuoc5kvRS0Hku0MoDWDUpADRaXPVHsOFLmxR16LJENj25ucCz5GEfeTGQ/tCE8JAypPmr/fQ==",
+      "bin": {
+        "stencil": "bin/stencil"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.10.0"
+      }
+    },
+    "node_modules/@arcgis/core/node_modules/dayjs": {
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
+      "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg=="
+    },
+    "node_modules/@arcgis/core/node_modules/sortablejs": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.2.tgz",
+      "integrity": "sha512-FJF5jgdfvoKn1MAKSdGs33bIqLi3LmsgVTliuX6iITj834F+JRQZN90Z93yql8h0K2t0RwDPBmxwlbZfDcxNZA=="
+    },
+    "node_modules/@arcgis/core/node_modules/type-fest": {
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.2.tgz",
+      "integrity": "sha512-+suCYpfJLAe4OXS6+PPXjW3urOS4IoP9waSiLuXfLgqZODKw/aWwASvzqE886wA0kQgGy0mIWyhd87VpqIy6Xg==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@aws-crypto/crc32": {
       "version": "3.0.0",
@@ -3650,22 +3741,6 @@
         "xss": "1.0.13"
       }
     },
-    "node_modules/@esri/arcgis-html-sanitizer/node_modules/xss": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.13.tgz",
-      "integrity": "sha512-clu7dxTm1e8Mo5fz3n/oW3UCXBfV89xZ72jM8yzo1vR/pIS0w3sgB3XV2H8Vm6zfGnHL0FzvLJPJEBhd86/z4Q==",
-      "dev": true,
-      "dependencies": {
-        "commander": "^2.20.3",
-        "cssfilter": "0.0.10"
-      },
-      "bin": {
-        "xss": "bin/xss"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
     "node_modules/@esri/arcgis-rest-auth": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.7.0.tgz",
@@ -3757,6 +3832,11 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.7.0.tgz",
       "integrity": "sha512-KEgORx0HKHOrV4oMYOwmZ76N89WTNkbKb1z3UYJrOEaKVGRU3jisgQcuTXFqjJJe4ZApGQhxCzNgcaU067qdpA=="
+    },
+    "node_modules/@esri/calcite-colors": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-colors/-/calcite-colors-6.1.0.tgz",
+      "integrity": "sha512-wHQYWFtDa6c328EraXEVZvgOiaQyYr0yuaaZ0G3cB4C3lSkWefW34L/e5TLAhtuG3zJ/wR6pl5X1YYNfBc0/4Q=="
     },
     "node_modules/@esri/calcite-components": {
       "version": "2.8.2",
@@ -4763,6 +4843,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.0.tgz",
+      "integrity": "sha512-yWJKmpGE6lUURKAaIltoPIE/wrbY3TEkqQt+X0m+7fQNnAv0keydnYvbiJFP1PnMhizmIWRWOG5KLhYyc/xl+g=="
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
+      "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4969,6 +5062,11 @@
         "@octokit/openapi-types": "^18.0.0"
       }
     },
+    "node_modules/@open-wc/dedupe-mixin": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@open-wc/dedupe-mixin/-/dedupe-mixin-1.4.0.tgz",
+      "integrity": "sha512-Sj7gKl1TLcDbF7B6KUhtvr+1UCxdhMbNY5KxdU5IfMFWqL8oy1ZeAcCANjoB1TL0AJTcPmcCFsCbHf8X2jGDUA=="
+    },
     "node_modules/@pdf-lib/fontkit": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@pdf-lib/fontkit/-/fontkit-1.1.1.tgz",
@@ -5013,6 +5111,14 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/@polymer/polymer": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.5.1.tgz",
+      "integrity": "sha512-JlAHuy+1qIC6hL1ojEUfIVD58fzTpJAoCxFwV5yr0mYTXV1H8bz5zy0+rC963Cgr9iNXQ4T9ncSjC2fkF9BQfw==",
+      "dependencies": {
+        "@webcomponents/shadycss": "^1.9.1"
       }
     },
     "node_modules/@puppeteer/browsers": {
@@ -5882,6 +5988,11 @@
       "integrity": "sha512-g7CK9nHdwjK2n0ymT2CW698FuWJRIx+RP6embAzZ2Qi8/ilIrA1Imt2LVSeHUzKvpoi7BhmmQcXz95eS0f2JXw==",
       "dev": true
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.29",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.29.tgz",
@@ -6349,6 +6460,187 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "node_modules/@vaadin/a11y-base": {
+      "version": "24.3.17",
+      "resolved": "https://registry.npmjs.org/@vaadin/a11y-base/-/a11y-base-24.3.17.tgz",
+      "integrity": "sha512-DJtrZ5W7WpUna6TrFSqf9SWM+JbnyVVHmVqHTmDQcQkqWBU3gKnL3exFbr8Vxy4jaJoIVxAW4XYdox75itysIA==",
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "~24.3.17",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/checkbox": {
+      "version": "24.3.17",
+      "resolved": "https://registry.npmjs.org/@vaadin/checkbox/-/checkbox-24.3.17.tgz",
+      "integrity": "sha512-blznPnm64SAlfMvtExqUbMS4bVFHyQD0HHOlK7uh4RWxHKGdM0mPtAXhUGnwAqR9i06v4EXSJ+yb29bXQET8fA==",
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "~24.3.17",
+        "@vaadin/component-base": "~24.3.17",
+        "@vaadin/field-base": "~24.3.17",
+        "@vaadin/vaadin-lumo-styles": "~24.3.17",
+        "@vaadin/vaadin-material-styles": "~24.3.17",
+        "@vaadin/vaadin-themable-mixin": "~24.3.17",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/component-base": {
+      "version": "24.3.17",
+      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.3.17.tgz",
+      "integrity": "sha512-zKKKgAXqe0GK/giCu/jzD30RiIPCbuh2INWuBgNV0FRB1lpKYoi0Ighx1EjtQwVZ+Kiug7rMaXteR3m4MFaxQA==",
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/vaadin-development-mode-detector": "^2.0.0",
+        "@vaadin/vaadin-usage-statistics": "^2.1.0",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/field-base": {
+      "version": "24.3.17",
+      "resolved": "https://registry.npmjs.org/@vaadin/field-base/-/field-base-24.3.17.tgz",
+      "integrity": "sha512-HJgWhYx7VXxQIKaIUD5oVqAA1BegPF/Zw3eD7eObdNd5CB8ExduELf+2vRmmmpYCiqVQEorOWOWyQssVZjLqhw==",
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "~24.3.17",
+        "@vaadin/component-base": "~24.3.17",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/grid": {
+      "version": "24.3.17",
+      "resolved": "https://registry.npmjs.org/@vaadin/grid/-/grid-24.3.17.tgz",
+      "integrity": "sha512-cc7btbQ0TbCHhXorTstBfgtbQ8eaP7nKO6bnkoaJLZUF6iMaJ8IGYDE00FJ5qSlL7adaXhPh2hFjj7XwiKk9uA==",
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "~24.3.17",
+        "@vaadin/checkbox": "~24.3.17",
+        "@vaadin/component-base": "~24.3.17",
+        "@vaadin/lit-renderer": "~24.3.17",
+        "@vaadin/text-field": "~24.3.17",
+        "@vaadin/vaadin-lumo-styles": "~24.3.17",
+        "@vaadin/vaadin-material-styles": "~24.3.17",
+        "@vaadin/vaadin-themable-mixin": "~24.3.17"
+      }
+    },
+    "node_modules/@vaadin/icon": {
+      "version": "24.3.17",
+      "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.3.17.tgz",
+      "integrity": "sha512-492hrMyXMzqNhYvF5DGnBpdcypSoXrjFyxDRotfvndaj4PIi92REt/JT89xZOPe5RJfzbr+8jF/ctLO6Ni862A==",
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "~24.3.17",
+        "@vaadin/vaadin-lumo-styles": "~24.3.17",
+        "@vaadin/vaadin-themable-mixin": "~24.3.17",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/input-container": {
+      "version": "24.3.17",
+      "resolved": "https://registry.npmjs.org/@vaadin/input-container/-/input-container-24.3.17.tgz",
+      "integrity": "sha512-6ZpXhtHEsq/zFDBILLMaM4dxDtmOuqJarWgb10W09H1CB1OSgJJVpJC67NfphTZN05R1rqzTNHqAQ2DKVyEdtw==",
+      "dependencies": {
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "~24.3.17",
+        "@vaadin/vaadin-lumo-styles": "~24.3.17",
+        "@vaadin/vaadin-material-styles": "~24.3.17",
+        "@vaadin/vaadin-themable-mixin": "~24.3.17",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/lit-renderer": {
+      "version": "24.3.17",
+      "resolved": "https://registry.npmjs.org/@vaadin/lit-renderer/-/lit-renderer-24.3.17.tgz",
+      "integrity": "sha512-/bOBrX+thOPjQMFau0yZG7Ts1rsDae8bA5d0Wj36Jz/ozRsR/eKAI1Jmxvz+9Mbu/G5+VGGcjqz1PSQJJqBvfA==",
+      "dependencies": {
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/text-field": {
+      "version": "24.3.17",
+      "resolved": "https://registry.npmjs.org/@vaadin/text-field/-/text-field-24.3.17.tgz",
+      "integrity": "sha512-Adwkss8aye1XkFNIvWFtL3bPOHUANcFo/SpsLPH1JTkVj8aWYhzhQ5XO1tSe5gBd0pvf9jHwT8cDjeLDLMyIAQ==",
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "~24.3.17",
+        "@vaadin/component-base": "~24.3.17",
+        "@vaadin/field-base": "~24.3.17",
+        "@vaadin/input-container": "~24.3.17",
+        "@vaadin/vaadin-lumo-styles": "~24.3.17",
+        "@vaadin/vaadin-material-styles": "~24.3.17",
+        "@vaadin/vaadin-themable-mixin": "~24.3.17",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/vaadin-development-mode-detector": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-development-mode-detector/-/vaadin-development-mode-detector-2.0.7.tgz",
+      "integrity": "sha512-9FhVhr0ynSR3X2ao+vaIEttcNU5XfzCbxtmYOV8uIRnUCtNgbvMOIcyGBvntsX9I5kvIP2dV3cFAOG9SILJzEA=="
+    },
+    "node_modules/@vaadin/vaadin-lumo-styles": {
+      "version": "24.3.17",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.3.17.tgz",
+      "integrity": "sha512-vnwfp615qiBIm1e8VRevxpcwpl02tDnM753ueIjy78l39aUJsA9wXx6DkPwm/Y8ofGNX9PAylEhf7c8lGkcw6Q==",
+      "dependencies": {
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "~24.3.17",
+        "@vaadin/icon": "~24.3.17",
+        "@vaadin/vaadin-themable-mixin": "~24.3.17"
+      }
+    },
+    "node_modules/@vaadin/vaadin-material-styles": {
+      "version": "24.3.17",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-material-styles/-/vaadin-material-styles-24.3.17.tgz",
+      "integrity": "sha512-BqmLCBxFlfNMmp3egpy7D1Ce3bnb8Caw+7XyFfotq6dhePiKuBM50+aj9EOo3Y8EodPAvzlwGJmXZs2y+ZoeNw==",
+      "dependencies": {
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "~24.3.17",
+        "@vaadin/vaadin-themable-mixin": "~24.3.17"
+      }
+    },
+    "node_modules/@vaadin/vaadin-themable-mixin": {
+      "version": "24.3.17",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.3.17.tgz",
+      "integrity": "sha512-xfQODW4tbwUjUC7Ss1WHzHYIoa3IEfXzjywKddv6HvgWiCDwpR+TocTjedJTmL0YaP5j1+i9YfFKy4N4nFn9vg==",
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/vaadin-usage-statistics": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.1.2.tgz",
+      "integrity": "sha512-xKs1PvRfTXsG0eWWcImLXWjv7D+f1vfoIvovppv6pZ5QX8xgcxWUdNgERlOOdGt3CTuxQXukTBW3+Qfva+OXSg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@vaadin/vaadin-development-mode-detector": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/@webcomponents/shadycss": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.11.2.tgz",
+      "integrity": "sha512-vRq+GniJAYSBmTRnhCYPAPq6THYqovJ/gzGThWbgEZUQaBccndGTi1hdiUP15HzEco0I6t4RCtXyX0rsSmwgPw=="
+    },
+    "node_modules/@zip.js/zip.js": {
+      "version": "2.7.47",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.47.tgz",
+      "integrity": "sha512-jmtJMA3/Jl4rMzo/DZ79s6g0CJ1AZcNAO6emTy/vHfIKAB/iiFY7PLs6KmbRTJ+F8GnK2eCLnjQfCCneRxXgzg==",
+      "engines": {
+        "bun": ">=0.7.0",
+        "deno": ">=1.0.0",
+        "node": ">=16.5.0"
+      }
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -7690,8 +7982,7 @@
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/composed-offset-position": {
       "version": "0.0.4",
@@ -7854,8 +8145,7 @@
     "node_modules/cssfilter": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
-      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
-      "dev": true
+      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
     },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
@@ -11830,6 +12120,34 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
+    "node_modules/lit": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.1.4.tgz",
+      "integrity": "sha512-q6qKnKXHy2g1kjBaNfcoLlgbI3+aSOZ9Q4tiGa9bGYXq5RBXxkVTqTIVmP2VWMp29L4GyvCFm8ZQ2o56eUAMyA==",
+      "dependencies": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit-element": "^4.0.4",
+        "lit-html": "^3.1.2"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.0.6.tgz",
+      "integrity": "sha512-U4sdJ3CSQip7sLGZ/uJskO5hGiqtlpxndsLr6mt3IQIjheg93UKYeGQjWMRql1s/cXNOaRrCzC2FQwjIwSUqkg==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.0.4",
+        "lit-html": "^3.1.2"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.1.4.tgz",
+      "integrity": "sha512-yKKO2uVv7zYFHlWMfZmqc+4hkmSbFp8jgjdZY9vvR9jr4J8fH6FUMXhr+ljfELgmjpvlF7Z1SJ5n5/Jeqtc9YA==",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
     "node_modules/load-json-file": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-6.2.0.tgz",
@@ -12005,6 +12323,14 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/luxon": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
+      "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -12051,6 +12377,17 @@
       "resolved": "https://registry.npmjs.org/maquette/-/maquette-3.6.0.tgz",
       "integrity": "sha512-Fb0zf/YGyYCj3t5JV8GOvYhprmKt2hFCCwomVCCMPwtr4abnsChJJYe297/a6AI14FIt5ZA8oVmeWWYjrmPaHQ==",
       "dev": true
+    },
+    "node_modules/marked": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -15702,6 +16039,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/xss": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.13.tgz",
+      "integrity": "sha512-clu7dxTm1e8Mo5fz3n/oW3UCXBfV89xZ72jM8yzo1vR/pIS0w3sgB3XV2H8Vm6zfGnHL0FzvLJPJEBhd86/z4Q==",
+      "dependencies": {
+        "commander": "^2.20.3",
+        "cssfilter": "0.0.10"
+      },
+      "bin": {
+        "xss": "bin/xss"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -15998,6 +16350,85 @@
       "resolved": "https://registry.npmjs.org/@analytics/type-utils/-/type-utils-0.3.1.tgz",
       "integrity": "sha512-9Ej6c9ulj5DNE29eFk3s49/1b89M8mbQ7BoJEQAQg/k86HOVrAEWQUScr359WVSOyGNBsSYE1qILC3XFTTtgtw==",
       "dev": true
+    },
+    "@arcgis/core": {
+      "version": "4.30.8",
+      "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.30.8.tgz",
+      "integrity": "sha512-nb1PwcPcqIKwSBb0wGF3DAHnA+G/2xcgXoZCVZQo4pvQSBTJQNvuXDxFhTCugsAAPh96FiQ4FL6ibEFO/jM9lA==",
+      "requires": {
+        "@esri/arcgis-html-sanitizer": "~4.0.3",
+        "@esri/calcite-colors": "~6.1.0",
+        "@esri/calcite-components": "^2.8.5",
+        "@vaadin/grid": "~24.3.13",
+        "@zip.js/zip.js": "~2.7.44",
+        "luxon": "~3.4.4",
+        "marked": "~12.0.2",
+        "sortablejs": "~1.15.2"
+      },
+      "dependencies": {
+        "@esri/arcgis-html-sanitizer": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-4.0.3.tgz",
+          "integrity": "sha512-B06V4Spjhcy2zcKH9SaTrZwRGjUTlsCSGImdCpe7fN/Q3HxLa4QosMgrRJQ+Q8guLhBA177+6Fjwzl/xIrmY7A==",
+          "requires": {
+            "xss": "1.0.13"
+          }
+        },
+        "@esri/calcite-components": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-2.10.1.tgz",
+          "integrity": "sha512-8M2ZBYcEk20x34TDxZ6H5rLCWtGrOJLtHA/k6yWL/GJTC85/gvY153XxbGN8F1ywJb/3imvhy/SlfNRPnVPQNQ==",
+          "requires": {
+            "@floating-ui/dom": "1.6.5",
+            "@stencil/core": "4.18.3",
+            "@types/color": "3.0.6",
+            "color": "4.2.3",
+            "composed-offset-position": "0.0.4",
+            "dayjs": "1.11.11",
+            "focus-trap": "7.5.4",
+            "lodash-es": "4.17.21",
+            "sortablejs": "1.15.1",
+            "timezone-groups": "0.8.0",
+            "type-fest": "4.18.2"
+          },
+          "dependencies": {
+            "sortablejs": {
+              "version": "1.15.1",
+              "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.1.tgz",
+              "integrity": "sha512-P5Cjvb0UG1ZVNiDPj/n4V+DinttXG6K8n7vM/HQf0C25K3YKQTQY6fsr/sEGsJGpQ9exmPxluHxKBc0mLKU1lQ=="
+            }
+          }
+        },
+        "@floating-ui/dom": {
+          "version": "1.6.5",
+          "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.5.tgz",
+          "integrity": "sha512-Nsdud2X65Dz+1RHjAIP0t8z5e2ff/IRbei6BqFrl1urT8sDVzM1HMQ+R0XcU5ceRfyO3I6ayeqIfh+6Wb8LGTw==",
+          "requires": {
+            "@floating-ui/core": "^1.0.0",
+            "@floating-ui/utils": "^0.2.0"
+          }
+        },
+        "@stencil/core": {
+          "version": "4.18.3",
+          "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.18.3.tgz",
+          "integrity": "sha512-8yoG5AFQYEPocVtuoc5kvRS0Hku0MoDWDUpADRaXPVHsOFLmxR16LJENj25ucCz5GEfeTGQ/tCE8JAypPmr/fQ=="
+        },
+        "dayjs": {
+          "version": "1.11.11",
+          "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
+          "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg=="
+        },
+        "sortablejs": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.2.tgz",
+          "integrity": "sha512-FJF5jgdfvoKn1MAKSdGs33bIqLi3LmsgVTliuX6iITj834F+JRQZN90Z93yql8h0K2t0RwDPBmxwlbZfDcxNZA=="
+        },
+        "type-fest": {
+          "version": "4.18.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.2.tgz",
+          "integrity": "sha512-+suCYpfJLAe4OXS6+PPXjW3urOS4IoP9waSiLuXfLgqZODKw/aWwASvzqE886wA0kQgGy0mIWyhd87VpqIy6Xg=="
+        }
+      }
     },
     "@aws-crypto/crc32": {
       "version": "3.0.0",
@@ -18497,18 +18928,6 @@
       "dev": true,
       "requires": {
         "xss": "1.0.13"
-      },
-      "dependencies": {
-        "xss": {
-          "version": "1.0.13",
-          "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.13.tgz",
-          "integrity": "sha512-clu7dxTm1e8Mo5fz3n/oW3UCXBfV89xZ72jM8yzo1vR/pIS0w3sgB3XV2H8Vm6zfGnHL0FzvLJPJEBhd86/z4Q==",
-          "dev": true,
-          "requires": {
-            "commander": "^2.20.3",
-            "cssfilter": "0.0.10"
-          }
-        }
       }
     },
     "@esri/arcgis-rest-auth": {
@@ -18596,6 +19015,11 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.7.0.tgz",
       "integrity": "sha512-KEgORx0HKHOrV4oMYOwmZ76N89WTNkbKb1z3UYJrOEaKVGRU3jisgQcuTXFqjJJe4ZApGQhxCzNgcaU067qdpA=="
+    },
+    "@esri/calcite-colors": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-colors/-/calcite-colors-6.1.0.tgz",
+      "integrity": "sha512-wHQYWFtDa6c328EraXEVZvgOiaQyYr0yuaaZ0G3cB4C3lSkWefW34L/e5TLAhtuG3zJ/wR6pl5X1YYNfBc0/4Q=="
     },
     "@esri/calcite-components": {
       "version": "2.8.2",
@@ -19363,6 +19787,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "@lit-labs/ssr-dom-shim": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.0.tgz",
+      "integrity": "sha512-yWJKmpGE6lUURKAaIltoPIE/wrbY3TEkqQt+X0m+7fQNnAv0keydnYvbiJFP1PnMhizmIWRWOG5KLhYyc/xl+g=="
+    },
+    "@lit/reactive-element": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
+      "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
+      "requires": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -19527,6 +19964,11 @@
         "@octokit/openapi-types": "^18.0.0"
       }
     },
+    "@open-wc/dedupe-mixin": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@open-wc/dedupe-mixin/-/dedupe-mixin-1.4.0.tgz",
+      "integrity": "sha512-Sj7gKl1TLcDbF7B6KUhtvr+1UCxdhMbNY5KxdU5IfMFWqL8oy1ZeAcCANjoB1TL0AJTcPmcCFsCbHf8X2jGDUA=="
+    },
     "@pdf-lib/fontkit": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@pdf-lib/fontkit/-/fontkit-1.1.1.tgz",
@@ -19563,6 +20005,14 @@
       "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
       "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
       "dev": true
+    },
+    "@polymer/polymer": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.5.1.tgz",
+      "integrity": "sha512-JlAHuy+1qIC6hL1ojEUfIVD58fzTpJAoCxFwV5yr0mYTXV1H8bz5zy0+rC963Cgr9iNXQ4T9ncSjC2fkF9BQfw==",
+      "requires": {
+        "@webcomponents/shadycss": "^1.9.1"
+      }
     },
     "@puppeteer/browsers": {
       "version": "2.2.4",
@@ -20290,6 +20740,11 @@
       "integrity": "sha512-g7CK9nHdwjK2n0ymT2CW698FuWJRIx+RP6embAzZ2Qi8/ilIrA1Imt2LVSeHUzKvpoi7BhmmQcXz95eS0f2JXw==",
       "dev": true
     },
+    "@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
+    },
     "@types/yargs": {
       "version": "17.0.29",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.29.tgz",
@@ -20578,6 +21033,178 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "@vaadin/a11y-base": {
+      "version": "24.3.17",
+      "resolved": "https://registry.npmjs.org/@vaadin/a11y-base/-/a11y-base-24.3.17.tgz",
+      "integrity": "sha512-DJtrZ5W7WpUna6TrFSqf9SWM+JbnyVVHmVqHTmDQcQkqWBU3gKnL3exFbr8Vxy4jaJoIVxAW4XYdox75itysIA==",
+      "requires": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "~24.3.17",
+        "lit": "^3.0.0"
+      }
+    },
+    "@vaadin/checkbox": {
+      "version": "24.3.17",
+      "resolved": "https://registry.npmjs.org/@vaadin/checkbox/-/checkbox-24.3.17.tgz",
+      "integrity": "sha512-blznPnm64SAlfMvtExqUbMS4bVFHyQD0HHOlK7uh4RWxHKGdM0mPtAXhUGnwAqR9i06v4EXSJ+yb29bXQET8fA==",
+      "requires": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "~24.3.17",
+        "@vaadin/component-base": "~24.3.17",
+        "@vaadin/field-base": "~24.3.17",
+        "@vaadin/vaadin-lumo-styles": "~24.3.17",
+        "@vaadin/vaadin-material-styles": "~24.3.17",
+        "@vaadin/vaadin-themable-mixin": "~24.3.17",
+        "lit": "^3.0.0"
+      }
+    },
+    "@vaadin/component-base": {
+      "version": "24.3.17",
+      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.3.17.tgz",
+      "integrity": "sha512-zKKKgAXqe0GK/giCu/jzD30RiIPCbuh2INWuBgNV0FRB1lpKYoi0Ighx1EjtQwVZ+Kiug7rMaXteR3m4MFaxQA==",
+      "requires": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/vaadin-development-mode-detector": "^2.0.0",
+        "@vaadin/vaadin-usage-statistics": "^2.1.0",
+        "lit": "^3.0.0"
+      }
+    },
+    "@vaadin/field-base": {
+      "version": "24.3.17",
+      "resolved": "https://registry.npmjs.org/@vaadin/field-base/-/field-base-24.3.17.tgz",
+      "integrity": "sha512-HJgWhYx7VXxQIKaIUD5oVqAA1BegPF/Zw3eD7eObdNd5CB8ExduELf+2vRmmmpYCiqVQEorOWOWyQssVZjLqhw==",
+      "requires": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "~24.3.17",
+        "@vaadin/component-base": "~24.3.17",
+        "lit": "^3.0.0"
+      }
+    },
+    "@vaadin/grid": {
+      "version": "24.3.17",
+      "resolved": "https://registry.npmjs.org/@vaadin/grid/-/grid-24.3.17.tgz",
+      "integrity": "sha512-cc7btbQ0TbCHhXorTstBfgtbQ8eaP7nKO6bnkoaJLZUF6iMaJ8IGYDE00FJ5qSlL7adaXhPh2hFjj7XwiKk9uA==",
+      "requires": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "~24.3.17",
+        "@vaadin/checkbox": "~24.3.17",
+        "@vaadin/component-base": "~24.3.17",
+        "@vaadin/lit-renderer": "~24.3.17",
+        "@vaadin/text-field": "~24.3.17",
+        "@vaadin/vaadin-lumo-styles": "~24.3.17",
+        "@vaadin/vaadin-material-styles": "~24.3.17",
+        "@vaadin/vaadin-themable-mixin": "~24.3.17"
+      }
+    },
+    "@vaadin/icon": {
+      "version": "24.3.17",
+      "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.3.17.tgz",
+      "integrity": "sha512-492hrMyXMzqNhYvF5DGnBpdcypSoXrjFyxDRotfvndaj4PIi92REt/JT89xZOPe5RJfzbr+8jF/ctLO6Ni862A==",
+      "requires": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "~24.3.17",
+        "@vaadin/vaadin-lumo-styles": "~24.3.17",
+        "@vaadin/vaadin-themable-mixin": "~24.3.17",
+        "lit": "^3.0.0"
+      }
+    },
+    "@vaadin/input-container": {
+      "version": "24.3.17",
+      "resolved": "https://registry.npmjs.org/@vaadin/input-container/-/input-container-24.3.17.tgz",
+      "integrity": "sha512-6ZpXhtHEsq/zFDBILLMaM4dxDtmOuqJarWgb10W09H1CB1OSgJJVpJC67NfphTZN05R1rqzTNHqAQ2DKVyEdtw==",
+      "requires": {
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "~24.3.17",
+        "@vaadin/vaadin-lumo-styles": "~24.3.17",
+        "@vaadin/vaadin-material-styles": "~24.3.17",
+        "@vaadin/vaadin-themable-mixin": "~24.3.17",
+        "lit": "^3.0.0"
+      }
+    },
+    "@vaadin/lit-renderer": {
+      "version": "24.3.17",
+      "resolved": "https://registry.npmjs.org/@vaadin/lit-renderer/-/lit-renderer-24.3.17.tgz",
+      "integrity": "sha512-/bOBrX+thOPjQMFau0yZG7Ts1rsDae8bA5d0Wj36Jz/ozRsR/eKAI1Jmxvz+9Mbu/G5+VGGcjqz1PSQJJqBvfA==",
+      "requires": {
+        "lit": "^3.0.0"
+      }
+    },
+    "@vaadin/text-field": {
+      "version": "24.3.17",
+      "resolved": "https://registry.npmjs.org/@vaadin/text-field/-/text-field-24.3.17.tgz",
+      "integrity": "sha512-Adwkss8aye1XkFNIvWFtL3bPOHUANcFo/SpsLPH1JTkVj8aWYhzhQ5XO1tSe5gBd0pvf9jHwT8cDjeLDLMyIAQ==",
+      "requires": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "~24.3.17",
+        "@vaadin/component-base": "~24.3.17",
+        "@vaadin/field-base": "~24.3.17",
+        "@vaadin/input-container": "~24.3.17",
+        "@vaadin/vaadin-lumo-styles": "~24.3.17",
+        "@vaadin/vaadin-material-styles": "~24.3.17",
+        "@vaadin/vaadin-themable-mixin": "~24.3.17",
+        "lit": "^3.0.0"
+      }
+    },
+    "@vaadin/vaadin-development-mode-detector": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-development-mode-detector/-/vaadin-development-mode-detector-2.0.7.tgz",
+      "integrity": "sha512-9FhVhr0ynSR3X2ao+vaIEttcNU5XfzCbxtmYOV8uIRnUCtNgbvMOIcyGBvntsX9I5kvIP2dV3cFAOG9SILJzEA=="
+    },
+    "@vaadin/vaadin-lumo-styles": {
+      "version": "24.3.17",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.3.17.tgz",
+      "integrity": "sha512-vnwfp615qiBIm1e8VRevxpcwpl02tDnM753ueIjy78l39aUJsA9wXx6DkPwm/Y8ofGNX9PAylEhf7c8lGkcw6Q==",
+      "requires": {
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "~24.3.17",
+        "@vaadin/icon": "~24.3.17",
+        "@vaadin/vaadin-themable-mixin": "~24.3.17"
+      }
+    },
+    "@vaadin/vaadin-material-styles": {
+      "version": "24.3.17",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-material-styles/-/vaadin-material-styles-24.3.17.tgz",
+      "integrity": "sha512-BqmLCBxFlfNMmp3egpy7D1Ce3bnb8Caw+7XyFfotq6dhePiKuBM50+aj9EOo3Y8EodPAvzlwGJmXZs2y+ZoeNw==",
+      "requires": {
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "~24.3.17",
+        "@vaadin/vaadin-themable-mixin": "~24.3.17"
+      }
+    },
+    "@vaadin/vaadin-themable-mixin": {
+      "version": "24.3.17",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.3.17.tgz",
+      "integrity": "sha512-xfQODW4tbwUjUC7Ss1WHzHYIoa3IEfXzjywKddv6HvgWiCDwpR+TocTjedJTmL0YaP5j1+i9YfFKy4N4nFn9vg==",
+      "requires": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "lit": "^3.0.0"
+      }
+    },
+    "@vaadin/vaadin-usage-statistics": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.1.2.tgz",
+      "integrity": "sha512-xKs1PvRfTXsG0eWWcImLXWjv7D+f1vfoIvovppv6pZ5QX8xgcxWUdNgERlOOdGt3CTuxQXukTBW3+Qfva+OXSg==",
+      "requires": {
+        "@vaadin/vaadin-development-mode-detector": "^2.0.0"
+      }
+    },
+    "@webcomponents/shadycss": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.11.2.tgz",
+      "integrity": "sha512-vRq+GniJAYSBmTRnhCYPAPq6THYqovJ/gzGThWbgEZUQaBccndGTi1hdiUP15HzEco0I6t4RCtXyX0rsSmwgPw=="
+    },
+    "@zip.js/zip.js": {
+      "version": "2.7.47",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.47.tgz",
+      "integrity": "sha512-jmtJMA3/Jl4rMzo/DZ79s6g0CJ1AZcNAO6emTy/vHfIKAB/iiFY7PLs6KmbRTJ+F8GnK2eCLnjQfCCneRxXgzg=="
     },
     "abab": {
       "version": "2.0.6",
@@ -21558,8 +22185,7 @@
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "composed-offset-position": {
       "version": "0.0.4",
@@ -21683,8 +22309,7 @@
     "cssfilter": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
-      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
-      "dev": true
+      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
     },
     "data-uri-to-buffer": {
       "version": "6.0.2",
@@ -24610,6 +25235,34 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
+    "lit": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.1.4.tgz",
+      "integrity": "sha512-q6qKnKXHy2g1kjBaNfcoLlgbI3+aSOZ9Q4tiGa9bGYXq5RBXxkVTqTIVmP2VWMp29L4GyvCFm8ZQ2o56eUAMyA==",
+      "requires": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit-element": "^4.0.4",
+        "lit-html": "^3.1.2"
+      }
+    },
+    "lit-element": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.0.6.tgz",
+      "integrity": "sha512-U4sdJ3CSQip7sLGZ/uJskO5hGiqtlpxndsLr6mt3IQIjheg93UKYeGQjWMRql1s/cXNOaRrCzC2FQwjIwSUqkg==",
+      "requires": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.0.4",
+        "lit-html": "^3.1.2"
+      }
+    },
+    "lit-html": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.1.4.tgz",
+      "integrity": "sha512-yKKO2uVv7zYFHlWMfZmqc+4hkmSbFp8jgjdZY9vvR9jr4J8fH6FUMXhr+ljfELgmjpvlF7Z1SJ5n5/Jeqtc9YA==",
+      "requires": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
     "load-json-file": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-6.2.0.tgz",
@@ -24753,6 +25406,11 @@
         "yallist": "^3.0.2"
       }
     },
+    "luxon": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
+      "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA=="
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -24792,6 +25450,11 @@
       "resolved": "https://registry.npmjs.org/maquette/-/maquette-3.6.0.tgz",
       "integrity": "sha512-Fb0zf/YGyYCj3t5JV8GOvYhprmKt2hFCCwomVCCMPwtr4abnsChJJYe297/a6AI14FIt5ZA8oVmeWWYjrmPaHQ==",
       "dev": true
+    },
+    "marked": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q=="
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -27474,6 +28137,15 @@
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
       "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
       "dev": true
+    },
+    "xss": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.13.tgz",
+      "integrity": "sha512-clu7dxTm1e8Mo5fz3n/oW3UCXBfV89xZ72jM8yzo1vR/pIS0w3sgB3XV2H8Vm6zfGnHL0FzvLJPJEBhd86/z4Q==",
+      "requires": {
+        "commander": "^2.20.3",
+        "cssfilter": "0.0.10"
+      }
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@types/node": "^20.14.10",
     "@typescript-eslint/eslint-plugin": "^7.13.1",
     "@typescript-eslint/parser": "^7.16.0",
-    "arcgis-js-api": "~4.29.10",
     "autoprefixer": "^10.4.19",
     "babel-jest": "^29.7.0",
     "braces": "^3.0.3",
@@ -80,6 +79,7 @@
     "typescript": "^5.5.3"
   },
   "dependencies": {
+    "@arcgis/core": "^4.30.8",
     "@esri/arcgis-rest-auth": "^3.7.0",
     "@esri/arcgis-rest-feature-layer": "^3.7.0",
     "@esri/arcgis-rest-portal": "^3.7.0",


### PR DESCRIPTION
1. The arcgis-js-api "[package is deprecated as of version 4.29 and the final release will be version 4.31.](https://www.npmjs.com/package/arcgis-js-api)"
2. It has defective definitions, which were what was causing PR #737 to fail.