### PR TITLE
update for regression

### DIFF
--- a/src/components/map-layer-picker/map-layer-picker.tsx
+++ b/src/components/map-layer-picker/map-layer-picker.tsx
@@ -17,7 +17,7 @@
 import { Component, Element, Event, EventEmitter, Host, h, Prop, State, VNode, Watch } from "@stencil/core";
 import MapLayerPicker_T9n from "../../assets/t9n/map-layer-picker/resources.json";
 import { getLocaleComponentStrings } from "../../utils/locale";
-import { getLayerOrTable, getMapLayerHash, getMapTableHash } from "../../utils/mapViewUtils";
+import { getMapLayerHash, getMapTableHash } from "../../utils/mapViewUtils";
 import state from "../../utils/publicNotificationStore";
 import { ILayerAndTableIds, ILayerHashInfo, IMapItemHash } from "../../utils/interfaces";
 
@@ -254,8 +254,10 @@ export class MapLayerPicker {
    */
   async componentWillRender(): Promise<void> {
     if (this.ids.length > 0 || this.selectedIds.length === 1) {
-      const layer = await getLayerOrTable(this.mapView, this.selectedIds[0]);
-      this.selectedName = layer?.title;
+      const id = this.selectedIds.length === 1 ? this.selectedIds[0] : this.ids[0];
+      if (id !== this.selectedIds[0]) {
+        this._setSelectedLayer(id);
+      }
     }
   }
 

--- a/src/components/map-select-tools/map-select-tools.tsx
+++ b/src/components/map-select-tools/map-select-tools.tsx
@@ -1144,7 +1144,8 @@ export class MapSelectTools {
       this._graphics = [];
       await this._drawTools.clear();
     }
-    this.selectionSetChange.emit(this._selectedIds.length);
+    this._numSelected = this._selectedIds.length;
+    this.selectionSetChange.emit(this._numSelected);
   }
 
   /**


### PR DESCRIPTION
@sumitzarkar the recent change here broke public notification. It needs the layer selection change event to fire here for the layer to be set prior to user selecting a layer manually. I opened up Manager and didn't see any issues right away but you may want to check for anything that this was done for. 