### PR TITLE
feat: update Manager legend setting respectLayerDefinitionExpression to true

### DIFF
--- a/src/components/map-legend/map-legend.tsx
+++ b/src/components/map-legend/map-legend.tsx
@@ -161,6 +161,7 @@ export class MapLegend {
       if (!this.legendWidget) {
         this.legendWidget = new this.Legend({
           container: this._legendElement,
+          respectLayerDefinitionExpression: true,
           view
         });
       } else {


### PR DESCRIPTION
## Summary
Update the respectLayerDefinitionExpression setting for the map legend to `true` so it aligns with the behavior of the Map Viewer.

## Testing (Manual)
- Selected a map that has different symbols according to the values of a particular field in the data set
- Created a filter on the field to exclude records that have certain values
- Added the map to the Manager app and saw that the values filtered out of the map still had a placeholder in the legend
- Installed a local version of this package with the changes applied
- Reloaded the app and confirmed that the symbols for the filtered out items were not present on the map or the legend